### PR TITLE
Fix 7 critical/high-severity bugs for production readiness

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -9,8 +9,8 @@
 #define FILECAST_VERSION "1.0.0"
 #endif
 
-namespace Receiver { void run(); }
-namespace Sender   { void run(); }
+namespace Receiver { int run(); }
+namespace Sender   { int run(); }
 
 
 static void cleanupAndExit(int code) {
@@ -176,14 +176,11 @@ int main(int argc, char* argv[]) {
                reinterpret_cast<const char*>(&tv), sizeof(tv));
     #endif
 
-    // Run receiver or sender
-    if (type == "receiver") {
-        Receiver::run();
-    } else {
-        Sender::run();
-    }
+    // Run receiver or sender; propagate its status as the process exit code so
+    // automation (deploy scripts, CI, Ansible) can tell success from failure.
+    int rc = (type == "receiver") ? Receiver::run() : Sender::run();
 
     CLOSE_SOCKET(_socket);
     CLEANUP_NETWORK();
-    return 0;
+    return rc;
 }

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -41,13 +41,14 @@ std::vector<size_t> getEmptyParts() {
  * Runs when "FINISH" packet is received
  * Gets empty parts and requests them from the server
  */
-void checkParts() {
+// Returns a process exit code: 0 on success, non-zero on failure.
+int checkParts() {
     char* buffer = new (std::nothrow) char[2 * mtu];
     if (!buffer) {
         std::cerr << "Error: Can't allocate receive buffer" << std::endl;
         delete[] file;
         file = nullptr;
-        return;
+        return 1;
     }
 
     std::vector<size_t> emptyParts = getEmptyParts();
@@ -112,7 +113,7 @@ void checkParts() {
         std::cerr << "Error: Transfer timed out, file is incomplete" << std::endl;
         delete[] file;
         file = nullptr;
-        return;
+        return 2;
     }
 
     std::ofstream output(fileName, std::ofstream::binary);
@@ -120,30 +121,32 @@ void checkParts() {
         std::cerr << "Error: Can't open output file " << fileName << std::endl;
         delete[] file;
         file = nullptr;
-        return;
+        return 2;
     }
     output.write(file, static_cast<std::streamsize>(file_length));
     if (!output) {
         std::cerr << "Error: Failed to write output file " << fileName << std::endl;
         delete[] file;
         file = nullptr;
-        return;
+        return 2;
     }
     output.close();
     std::cout << "File successfully received" << std::endl;
 
     delete[] file;
     file = nullptr;
+    return 0;
 }
 
 
-void run() {
+// Returns a process exit code: 0 on success, non-zero on failure.
+int run() {
     bool finish = false; // Sender finished transferring
 
     char* buffer = new (std::nothrow) char[2 * mtu];
     if (!buffer) {
         std::cerr << "Error: Can't allocate receive buffer" << std::endl;
-        return;
+        return 1;
     }
 
     while (ttl > 0) {
@@ -152,12 +155,11 @@ void run() {
         if (finish) {
             if (file != nullptr) {
                 delete[] buffer;
-                checkParts();
-                return;
+                return checkParts();
             }
             std::cerr << "Error: Received FINISH without NEW_PACKET — joined too late" << std::endl;
             delete[] buffer;
-            return;
+            return 2;
         }
 
         auto length = recvfrom(_socket, buffer, 2 * mtu, 0,
@@ -186,13 +188,13 @@ void run() {
             if (announced == 0) {
                 std::cerr << "Error: Sender announced empty file" << std::endl;
                 delete[] buffer;
-                return;
+                return 2;
             }
             if (announced > MAX_FILE_LENGTH) {
                 std::cerr << "Error: Sender announced file size " << announced
                           << " bytes, exceeds limit of " << MAX_FILE_LENGTH << std::endl;
                 delete[] buffer;
-                return;
+                return 2;
             }
 
             // Sender retransmits NEW_PACKET a few times for robustness; if we
@@ -208,7 +210,7 @@ void run() {
             if (!file) {
                 std::cerr << "Error: Can't allocate " << file_length << " bytes" << std::endl;
                 delete[] buffer;
-                return;
+                return 1;
             }
             memset(file, 0, file_length);
 
@@ -243,9 +245,11 @@ void run() {
             }
         }
     }
+    // ttl exhausted before FINISH: the transfer did not complete.
     delete[] buffer;
     delete[] file;
     file = nullptr;
+    return 2;
 }
 
 } //namespace Receiver

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -20,6 +20,13 @@ namespace Receiver {
 // only if you know the receiver has enough memory.
 constexpr size_t MAX_FILE_LENGTH = 4ULL * 1024 * 1024 * 1024; // 4 GiB
 
+// Session the receiver is currently bound to. The sender stamps a random id into
+// every packet; we latch it from the first NEW_PACKET and then reject packets
+// from any other session, so a second sender (or a restarted one) cannot mix a
+// different file into our buffer and have us report success on garbage.
+size_t session_id   = 0;
+bool   have_session = false;
+
 /**
  * List of received parts
  */
@@ -56,8 +63,9 @@ int checkParts() {
     while (ttl && !emptyParts.empty()) {
         for (auto index : emptyParts) {
             snprintf(buffer, 7, "RESEND");
-            Utils::writeBytesFromNumber(buffer + 6, index, 4);
-            sendto(_socket, buffer, 10, 0, reinterpret_cast<sockaddr*>(&broadcast_address),
+            Utils::writeBytesFromNumber(buffer +  6, session_id, 4);
+            Utils::writeBytesFromNumber(buffer + 10, index,      4);
+            sendto(_socket, buffer, 14, 0, reinterpret_cast<sockaddr*>(&broadcast_address),
                    sizeof(broadcast_address));
             std::cout << "Request part of file with index " << index << std::endl;
             if (delay_ms > 0) std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
@@ -79,9 +87,11 @@ int checkParts() {
                                    &sender_address_length);
             if (length <= 0) break;                              // queue drained this round
             if (strncmp(buffer, "TRANSFER", 8) != 0) continue;   // e.g. our own RESEND
+            if (static_cast<size_t>(length) < 20) continue;
+            if (Utils::getNumberFromBytes(buffer + 8, 4) != session_id) continue;
 
-            size_t part        = Utils::getNumberFromBytes(buffer +  8, 4);
-            size_t size        = Utils::getNumberFromBytes(buffer + 12, 4);
+            size_t part        = Utils::getNumberFromBytes(buffer + 12, 4);
+            size_t size        = Utils::getNumberFromBytes(buffer + 16, 4);
             size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
 
             // For non-final parts size must equal MTU; for the final part it must
@@ -91,9 +101,9 @@ int checkParts() {
                 ? static_cast<size_t>(mtu)
                 : (file_length - part * static_cast<size_t>(mtu));
             if (part < total_parts && parts.find(part) == parts.end() &&
-                size == expected && static_cast<size_t>(length) >= size + 16) {
+                size == expected && static_cast<size_t>(length) >= size + 20) {
                 parts.insert(part);
-                memcpy(file + part * static_cast<size_t>(mtu), buffer + 16, size);
+                memcpy(file + part * static_cast<size_t>(mtu), buffer + 20, size);
                 std::cout << "Receive " << part << " part with size " << size << std::endl;
                 progressed = true;
             }
@@ -179,13 +189,20 @@ int run() {
             continue;
         }
 
-        if (strncmp(buffer, "NEW_PACKET", 10) == 0 && static_cast<size_t>(length) >= 14) {
-            // Only a recognised protocol packet from the sender refreshes ttl.
-            // Unrecognised traffic (stray broadcasts, other receivers' RESENDs,
-            // garbage) deliberately does not, so the timeout stays reachable and
-            // a hostile or noisy host cannot keep the receiver alive forever.
+        if (strncmp(buffer, "NEW_PACKET", 10) == 0 && static_cast<size_t>(length) >= 18) {
+            size_t incoming_sid = Utils::getNumberFromBytes(buffer + 10, 4);
+            // A NEW_PACKET from a different session (a second sender, or our own
+            // sender restarted) must not clobber the transfer already in progress.
+            if (have_session && incoming_sid != session_id) {
+                std::cerr << "Warning: ignoring NEW_PACKET from another sender session" << std::endl;
+                continue;
+            }
+            // Only a recognised packet from our sender refreshes ttl. Unrecognised
+            // traffic (stray broadcasts, other receivers' RESENDs, garbage)
+            // deliberately does not, so the timeout stays reachable and a hostile
+            // or noisy host cannot keep the receiver alive forever.
             ttl = ttl_max;
-            size_t announced = Utils::getNumberFromBytes(buffer + 10, 4);
+            size_t announced = Utils::getNumberFromBytes(buffer + 14, 4);
             if (announced == 0) {
                 std::cerr << "Error: Sender announced empty file" << std::endl;
                 delete[] buffer;
@@ -203,7 +220,9 @@ int run() {
             // duplicate and keep accumulated parts.
             if (file != nullptr && announced == file_length) continue;
 
-            file_length = announced;
+            session_id   = incoming_sid;
+            have_session = true;
+            file_length  = announced;
 
             delete[] file;
             parts.clear();
@@ -218,8 +237,10 @@ int run() {
             std::cout << "Receive information about new file size: " << file_length << std::endl;
             std::cout << "Number of parts: " << (file_length + mtu - 1) / mtu << std::endl;
         } else if (strncmp(buffer, "TRANSFER", 8) == 0 && file != nullptr) {
-            size_t part        = Utils::getNumberFromBytes(buffer +  8, 4); // Read section "index"
-            size_t size        = Utils::getNumberFromBytes(buffer + 12, 4); // Read section "size"
+            if (static_cast<size_t>(length) < 20) continue;
+            if (Utils::getNumberFromBytes(buffer + 8, 4) != session_id) continue;
+            size_t part        = Utils::getNumberFromBytes(buffer + 12, 4); // Read section "index"
+            size_t size        = Utils::getNumberFromBytes(buffer + 16, 4); // Read section "size"
             size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
 
             if (part >= total_parts) continue;
@@ -230,14 +251,16 @@ int run() {
                 ? static_cast<size_t>(mtu)
                 : (file_length - part * static_cast<size_t>(mtu));
             if (size != expected) continue;
-            if (static_cast<size_t>(length) < size + 16) continue;
+            if (static_cast<size_t>(length) < size + 20) continue;
 
             ttl = ttl_max;
             parts.insert(part);
             std::cout << "Receive " << part << " part with size " << size << std::endl;
 
-            memcpy(file + part * static_cast<size_t>(mtu), buffer + 16, size);
+            memcpy(file + part * static_cast<size_t>(mtu), buffer + 20, size);
         } else if (strncmp(buffer, "FINISH", 6) == 0) {
+            if (static_cast<size_t>(length) < 10) continue;
+            if (Utils::getNumberFromBytes(buffer + 6, 4) != session_id) continue;
             ttl = ttl_max;
             // If receiver didn't receive a finish message
             if (!finish) {

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -73,27 +73,35 @@ void checkParts() {
             continue;
         }
 
-        ttl = ttl_max;
-
+        // Only a valid, wanted TRANSFER counts as progress and refreshes ttl.
+        // Everything else — most importantly our own broadcast RESENDs looped
+        // back to us by the OS in the default (--broadcast yes, port==bind-port)
+        // configuration — must count down toward the timeout. Otherwise, once
+        // the sender goes away, the receiver never times out: it endlessly
+        // re-requests the same parts and floods the LAN with RESENDs forever.
+        bool progressed = false;
         if (strncmp(buffer, "TRANSFER", 8) == 0) {
             size_t part        = Utils::getNumberFromBytes(buffer +  8, 4);
             size_t size        = Utils::getNumberFromBytes(buffer + 12, 4);
             size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
 
-            if (part >= total_parts) continue;
             // For non-final parts size must equal MTU; for the final part it must
             // equal the remaining bytes. Anything else is malformed and would
             // either silently zero-pad data or write past the file buffer.
             size_t expected = (part + 1 < total_parts)
                 ? static_cast<size_t>(mtu)
                 : (file_length - part * static_cast<size_t>(mtu));
-            if (size != expected) continue;
-            if (static_cast<size_t>(length) < size + 16) continue;
-
-            parts.insert(part);
-            memcpy(file + part * static_cast<size_t>(mtu), buffer + 16, size);
-            std::cout << "Receive " << part << " part with size " << size << std::endl;
+            if (part < total_parts && size == expected &&
+                static_cast<size_t>(length) >= size + 16) {
+                parts.insert(part);
+                memcpy(file + part * static_cast<size_t>(mtu), buffer + 16, size);
+                std::cout << "Receive " << part << " part with size " << size << std::endl;
+                progressed = true;
+            }
         }
+
+        if (progressed) ttl = ttl_max;
+        else            ttl--;
 
         emptyParts = getEmptyParts();
     }
@@ -168,9 +176,12 @@ void run() {
             continue;
         }
 
-        ttl = ttl_max; // Update ttl
-
         if (strncmp(buffer, "NEW_PACKET", 10) == 0 && static_cast<size_t>(length) >= 14) {
+            // Only a recognised protocol packet from the sender refreshes ttl.
+            // Unrecognised traffic (stray broadcasts, other receivers' RESENDs,
+            // garbage) deliberately does not, so the timeout stays reachable and
+            // a hostile or noisy host cannot keep the receiver alive forever.
+            ttl = ttl_max;
             size_t announced = Utils::getNumberFromBytes(buffer + 10, 4);
             if (announced == 0) {
                 std::cerr << "Error: Sender announced empty file" << std::endl;
@@ -218,11 +229,13 @@ void run() {
             if (size != expected) continue;
             if (static_cast<size_t>(length) < size + 16) continue;
 
+            ttl = ttl_max;
             parts.insert(part);
             std::cout << "Receive " << part << " part with size " << size << std::endl;
 
             memcpy(file + part * static_cast<size_t>(mtu), buffer + 16, size);
         } else if (strncmp(buffer, "FINISH", 6) == 0) {
+            ttl = ttl_max;
             // If receiver didn't receive a finish message
             if (!finish) {
                 std::cout << "Server finished transferring" << std::endl;

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -138,34 +138,33 @@ void run() {
         return;
     }
 
-    while (auto length = recvfrom(_socket, buffer, 2 * mtu, 0,
-                                  reinterpret_cast<sockaddr*>(&server_address),
-                                  &server_address_length)) {
-        // Sender is no longer available
-        if (ttl <= 0) {
-            delete[] buffer;
-            delete[] file;
-            file = nullptr;
-            return;
-        }
-
-        // Got FINISH but never received NEW_PACKET — joined too late or sender
-        // misbehaving. Bail with an error rather than waiting for ttl to drain.
-        if (finish && file == nullptr) {
+    while (ttl > 0) {
+        // Sender finished transferring — move to the recovery phase (or bail if
+        // we joined too late to ever have received NEW_PACKET).
+        if (finish) {
+            if (file != nullptr) {
+                delete[] buffer;
+                checkParts();
+                return;
+            }
             std::cerr << "Error: Received FINISH without NEW_PACKET — joined too late" << std::endl;
             delete[] buffer;
             return;
         }
 
-        // If Sender finished transferring, check missing parts
-        if (finish && file != nullptr) {
-            delete[] buffer;
-            checkParts();
-            return;
-        }
+        auto length = recvfrom(_socket, buffer, 2 * mtu, 0,
+                               reinterpret_cast<sockaddr*>(&server_address),
+                               &server_address_length);
 
-        if (length <= 0) {
+        // Timeout (SO_RCVTIMEO) or socket error: count down toward giving up.
+        if (length < 0) {
             ttl--;
+            continue;
+        }
+        // A zero-length datagram is a valid UDP event; ignore it. Using the
+        // recvfrom return value as the loop condition previously let any host
+        // terminate the receiver (exit 0, no file written) with one empty packet.
+        if (length == 0) {
             continue;
         }
 

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -63,25 +63,23 @@ int checkParts() {
             if (delay_ms > 0) std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
         }
 
+        // Drain every packet already queued (until the socket times out via
+        // SO_RCVTIMEO), applying each valid, wanted TRANSFER. Reading only one
+        // packet per round made recovery O(N^2) in the number of missing parts:
+        // one part recovered per round while re-requesting all of them, so N
+        // losses took ~N^2 * delay to recover and buried the sender's replies.
         SOCKADDR_IN sender_address;
         memset(&sender_address, 0, sizeof(sender_address));
         addr_len sender_address_length = sizeof(sender_address);
-        auto length = recvfrom(_socket, buffer, 2 * mtu, 0,
-                               reinterpret_cast<sockaddr*>(&sender_address), &sender_address_length);
 
-        if (length <= 0) {
-            ttl--;
-            continue;
-        }
-
-        // Only a valid, wanted TRANSFER counts as progress and refreshes ttl.
-        // Everything else — most importantly our own broadcast RESENDs looped
-        // back to us by the OS in the default (--broadcast yes, port==bind-port)
-        // configuration — must count down toward the timeout. Otherwise, once
-        // the sender goes away, the receiver never times out: it endlessly
-        // re-requests the same parts and floods the LAN with RESENDs forever.
         bool progressed = false;
-        if (strncmp(buffer, "TRANSFER", 8) == 0) {
+        while (true) {
+            auto length = recvfrom(_socket, buffer, 2 * mtu, 0,
+                                   reinterpret_cast<sockaddr*>(&sender_address),
+                                   &sender_address_length);
+            if (length <= 0) break;                              // queue drained this round
+            if (strncmp(buffer, "TRANSFER", 8) != 0) continue;   // e.g. our own RESEND
+
             size_t part        = Utils::getNumberFromBytes(buffer +  8, 4);
             size_t size        = Utils::getNumberFromBytes(buffer + 12, 4);
             size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
@@ -92,8 +90,8 @@ int checkParts() {
             size_t expected = (part + 1 < total_parts)
                 ? static_cast<size_t>(mtu)
                 : (file_length - part * static_cast<size_t>(mtu));
-            if (part < total_parts && size == expected &&
-                static_cast<size_t>(length) >= size + 16) {
+            if (part < total_parts && parts.find(part) == parts.end() &&
+                size == expected && static_cast<size_t>(length) >= size + 16) {
                 parts.insert(part);
                 memcpy(file + part * static_cast<size_t>(mtu), buffer + 16, size);
                 std::cout << "Receive " << part << " part with size " << size << std::endl;
@@ -101,6 +99,9 @@ int checkParts() {
             }
         }
 
+        // A new part refreshes ttl; a round with no progress counts down toward
+        // the timeout. Our own looped-back RESENDs are not TRANSFERs, so a dead
+        // sender still lets recovery terminate instead of livelocking.
         if (progressed) ttl = ttl_max;
         else            ttl--;
 

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -7,14 +7,22 @@
 #include <chrono>
 #include <cstring>
 #include <cstdio>
+#include <cstdint>
 #include <map>
+#include <random>
 
 using namespace std::chrono_literals;
 
 
 namespace Sender {
 
-constexpr int HEADER_SIZE = 16;
+// TRANSFER header: "TRANSFER"(8) + session id(4) + part number(4) + length(4).
+constexpr int HEADER_SIZE = 20;
+
+// Random per-transfer id, generated in run() and stamped into every packet so a
+// receiver can reject packets from a different sender (a second concurrent
+// sender, or a restart) instead of silently mixing two files into one buffer.
+uint32_t session_id = 0;
 
 // The file size is announced in a 4-byte field in NEW_PACKET, so anything that
 // does not fit into 32 bits would be silently truncated on the wire (a 4 GiB
@@ -34,9 +42,10 @@ void sendPart(size_t part_index) {
     if (packet_length > static_cast<size_t>(mtu)) packet_length = static_cast<size_t>(mtu);
 
     snprintf(buffer, 9, "TRANSFER");
-    Utils::writeBytesFromNumber(buffer +  8, part_index,    4); // Write section "number"
-    Utils::writeBytesFromNumber(buffer + 12, packet_length, 4); // Write section "length"
-    memcpy(buffer + 16, file + offset, packet_length);          // Write section "data"
+    Utils::writeBytesFromNumber(buffer +  8, session_id,    4); // Write section "session"
+    Utils::writeBytesFromNumber(buffer + 12, part_index,    4); // Write section "number"
+    Utils::writeBytesFromNumber(buffer + 16, packet_length, 4); // Write section "length"
+    memcpy(buffer + 20, file + offset, packet_length);          // Write section "data"
 
     auto sent = sendto(_socket, buffer, static_cast<int>(packet_length + HEADER_SIZE), 0,
                        reinterpret_cast<sockaddr*>(&broadcast_address), sizeof(broadcast_address));
@@ -115,13 +124,17 @@ int run() {
 
     std::cout << "Ok: File successfully copied to RAM" << std::endl;
 
+    std::random_device rd;
+    session_id = static_cast<uint32_t>(rd());
+
     snprintf(buffer, 11, "NEW_PACKET");
-    Utils::writeBytesFromNumber(buffer + 10, file_length, 4);
+    Utils::writeBytesFromNumber(buffer + 10, session_id, 4);
+    Utils::writeBytesFromNumber(buffer + 14, file_length, 4);
     // NEW_PACKET is sent only once (no RESEND mechanism for it), so a single
     // dropped packet would strand every receiver. Retransmit a few times to
     // make the start of the transfer robust to typical LAN loss.
     for (int i = 0; i < 3; ++i) {
-        if (sendto(_socket, buffer, 14, 0,
+        if (sendto(_socket, buffer, 18, 0,
                    reinterpret_cast<sockaddr*>(&broadcast_address),
                    sizeof(broadcast_address)) < 0) {
             std::cerr << "Warning: Failed to send NEW_PACKET" << std::endl;
@@ -142,7 +155,8 @@ int run() {
     }
 
     snprintf(buffer, 7, "FINISH");
-    if (sendto(_socket, buffer, 6, 0,
+    Utils::writeBytesFromNumber(buffer + 6, session_id, 4);
+    if (sendto(_socket, buffer, 10, 0,
                reinterpret_cast<sockaddr*>(&broadcast_address),
                sizeof(broadcast_address)) < 0) {
         std::cerr << "Warning: Failed to send FINISH" << std::endl;
@@ -168,7 +182,8 @@ int run() {
         if (result <= 0) {
             ttl--;
             snprintf(buffer, 7, "FINISH");
-            if (sendto(_socket, buffer, 6, 0,
+            Utils::writeBytesFromNumber(buffer + 6, session_id, 4);
+            if (sendto(_socket, buffer, 10, 0,
                        reinterpret_cast<sockaddr*>(&broadcast_address),
                        sizeof(broadcast_address)) < 0) {
                 std::cerr << "Warning: Failed to send FINISH" << std::endl;
@@ -177,7 +192,11 @@ int run() {
         }
 
         if (strncmp(buffer, "RESEND", 6) == 0) {
-            size_t part = Utils::getNumberFromBytes(buffer + 6, 4);
+            // Ignore RESENDs shorter than the header or belonging to a different
+            // session (another sender's receivers requesting their own transfer).
+            if (result < 14) continue;
+            if (Utils::getNumberFromBytes(buffer + 6, 4) != session_id) continue;
+            size_t part = Utils::getNumberFromBytes(buffer + 10, 4);
 
             if (part >= total_parts) continue;
 
@@ -197,7 +216,8 @@ int run() {
             if (duration - lastFinishSendTime >= 1) {
                 lastFinishSendTime = duration;
                 snprintf(buffer, 7, "FINISH");
-                if (sendto(_socket, buffer, 6, 0,
+                Utils::writeBytesFromNumber(buffer + 6, session_id, 4);
+                if (sendto(_socket, buffer, 10, 0,
                            reinterpret_cast<sockaddr*>(&broadcast_address),
                            sizeof(broadcast_address)) < 0) {
                     std::cerr << "Warning: Failed to send FINISH" << std::endl;

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -155,7 +155,12 @@ void run() {
     addr_len sender_address_length = sizeof(sender_address);
 
     while (ttl) {
-        auto result = recvfrom(_socket, buffer, 100, 0,
+        // Read into the full buffer (2 * mtu). The socket is bound to the same
+        // port we broadcast to, so the OS also delivers copies of our own
+        // TRANSFER packets here; on Windows a 100-byte buffer made those
+        // oversized datagrams fail with WSAEMSGSIZE, which was misread as a
+        // timeout and prematurely drained ttl, killing the resend phase.
+        auto result = recvfrom(_socket, buffer, 2 * mtu, 0,
                                reinterpret_cast<sockaddr*>(&sender_address), &sender_address_length);
 
         // No incoming requests for a while - resend FINISH and decrement ttl.

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -16,6 +16,11 @@ namespace Sender {
 
 constexpr int HEADER_SIZE = 16;
 
+// The file size is announced in a 4-byte field in NEW_PACKET, so anything that
+// does not fit into 32 bits would be silently truncated on the wire (a 4 GiB
+// file would be announced as 0). Reject such files up front instead.
+constexpr size_t MAX_WIRE_FILE_LENGTH = 0xFFFFFFFFULL;
+
 /**
  * Since server may receive many requests for sending some part
  * It is necessary to limit the sending of the same parts for a while
@@ -70,6 +75,17 @@ void run() {
 
     if (file_length == 0) {
         std::cerr << "Error: File is empty" << std::endl;
+        delete[] buffer;
+        buffer = nullptr;
+        CLOSE_SOCKET(_socket);
+        CLEANUP_NETWORK();
+        exit(-1);
+    }
+
+    if (file_length > MAX_WIRE_FILE_LENGTH) {
+        std::cerr << "Error: File is too large (" << file_length
+                  << " bytes); the 4-byte wire format supports at most "
+                  << MAX_WIRE_FILE_LENGTH << " bytes" << std::endl;
         delete[] buffer;
         buffer = nullptr;
         CLOSE_SOCKET(_socket);

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -47,7 +47,8 @@ void sendPart(size_t part_index) {
     std::cout << "Part " << part_index << " with size " << packet_length << " was sent" << std::endl;
 }
 
-void run() {
+// Returns a process exit code: 0 on success, non-zero on failure.
+int run() {
     buffer = new char[2 * mtu];
 
     std::ifstream input(fileName, std::ios::binary);
@@ -57,7 +58,7 @@ void run() {
         buffer = nullptr;
         CLOSE_SOCKET(_socket);
         CLEANUP_NETWORK();
-        exit(-1);
+        return 1;
     }
 
     input.seekg(0, std::ios::end);
@@ -68,7 +69,7 @@ void run() {
         buffer = nullptr;
         CLOSE_SOCKET(_socket);
         CLEANUP_NETWORK();
-        exit(-1);
+        return 1;
     }
     file_length = static_cast<size_t>(end_pos);
     input.seekg(0, std::ios::beg);
@@ -79,7 +80,7 @@ void run() {
         buffer = nullptr;
         CLOSE_SOCKET(_socket);
         CLEANUP_NETWORK();
-        exit(-1);
+        return 1;
     }
 
     if (file_length > MAX_WIRE_FILE_LENGTH) {
@@ -90,7 +91,7 @@ void run() {
         buffer = nullptr;
         CLOSE_SOCKET(_socket);
         CLEANUP_NETWORK();
-        exit(-1);
+        return 1;
     }
 
     file = new (std::nothrow) char[file_length];
@@ -100,7 +101,7 @@ void run() {
         buffer = nullptr;
         CLOSE_SOCKET(_socket);
         CLEANUP_NETWORK();
-        exit(-1);
+        return 1;
     }
     input.read(file, static_cast<std::streamsize>(file_length));
     if (static_cast<size_t>(input.gcount()) != file_length) {
@@ -109,7 +110,7 @@ void run() {
         delete[] buffer; buffer = nullptr;
         CLOSE_SOCKET(_socket);
         CLEANUP_NETWORK();
-        exit(-1);
+        return 1;
     }
 
     std::cout << "Ok: File successfully copied to RAM" << std::endl;
@@ -210,6 +211,7 @@ void run() {
     delete[] file;
     buffer = nullptr;
     file   = nullptr;
+    return 0;
 }
 
 


### PR DESCRIPTION
Исправляет 7 критичных/high багов, найденных в ходе многоагентного аудита (по одному атомарному коммиту на баг). Каждый коммит собирается и проходит `ctest` (unit + e2e + e2e_lossy).

| Коммит | Баг | Суть фикса |
|--------|-----|-----------|
| `6c3df88` | Файлы ≥ 4 ГиБ | Sender отклоняет файлы > 0xFFFFFFFF (раньше размер молча усекался в 4-байтовом поле NEW_PACKET) |
| `07b2644` | recvfrom 100 байт | Sender читает ответы в полный буфер `2*mtu` (WSAEMSGSIZE ломал докачку на Windows) |
| `48d1750` | Пустая датаграмма | Цикл `Receiver::run` идёт по `ttl`, а не по возврату recvfrom; `len==0` игнорируется (был DoS одним пакетом + выход с кодом 0) |
| `336bdfb` | Livelock/broadcast-шторм | `ttl` обновляется только на распознанный прогресс, а не на любой пакет (в т.ч. собственные looped-back RESEND) |
| `37e73e8` | Коды возврата | `run()`/`checkParts()` возвращают статус, `main` пробрасывает его (0/1/2 вместо всегда 0) — критично для скриптовой раскатки |
| `0c3b9ab` | O(N²) восстановление | `checkParts` дренирует всю очередь за раунд, а не читает один пакет |
| `103fd5f` | Нет session-id | Случайный 32-битный session-id во всех пакетах; чужая сессия/второй sender отбрасываются вместо тихой порчи файла |

**Верификация:** полный `ctest` зелёный после каждого коммита; отдельно воспроизведены и подтверждены фиксы livelock (#1), кодов возврата (#7) и session-фильтра (#3).

**⚠️ Несовместимость протокола:** коммит session-id меняет проволочный формат (заголовок TRANSFER 16→20 байт, добавлены sid в NEW_PACKET/FINISH/RESEND). Несовместимо со старыми бинарниками — обе стороны должны быть одной версии. При релизе стоит поднять версию и добавить поле версии протокола (отдельная задача).