### PR TITLE
Protocol v2: SHA-256 integrity, file name, negotiated chunk size

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ LAN at once, with automatic retransmission of dropped packets.
 - Broadcast to every host on a LAN with a single transmission
 - Unicast mode for point-to-point transfer
 - Automatic retransmission of lost packets
+- End-to-end SHA-256 integrity check — a corrupted file is rejected, not saved
+- File name travels with the transfer, so `receive` needs no arguments
+- Chunk size negotiated in-band, so mismatched `--mtu` no longer stalls
 - Configurable MTU and timeout
 - Windows, Linux, and macOS binaries built on every release
 
@@ -52,8 +55,11 @@ directly. No installation required.
 **Receiver** (one or more hosts on the same LAN):
 
 ```sh
-./filecast receive photo.jpg
+./filecast receive
 ```
+
+The file is saved under the name the sender announced (pass a path to override
+it, e.g. `./filecast receive my-photo.jpg`).
 
 Send to a specific host instead of broadcasting to the whole LAN:
 
@@ -72,14 +78,14 @@ If your platform isn't covered, see [Building from Source](#building-from-source
 
 ```sh
 filecast send <file> [options]       # broadcast a file to the LAN
-filecast receive [file] [options]    # receive a file (default: file.out)
+filecast receive [file] [options]    # receive a file (default: name from sender)
 ```
 
 ## Parameters
 
 | Parameter | Default | Range | Description |
 | --------- | ------- | ----- | ----------- |
-| `<file>` (positional) | — (send) / `file.out` (receive) | — | File to send, or where to save it. `-f, --file` is an alias |
+| `<file>` (positional) | — (send) / name from sender (receive) | — | File to send, or where to save it. `-f, --file` is an alias |
 | `--to`        | broadcast  | IPv4 | Send to one host instead of LAN broadcast |
 | `-p, --port`  | `33333`    | 1..65535 | Destination port for outgoing packets |
 | `--bind-port` | `33333`    | 1..65535 | Local port to bind on |
@@ -126,30 +132,40 @@ development):
 
 ## How It Works
 
-1. Sender broadcasts a `NEW_PACKET` packet with the total file size.
-2. Each receiver allocates a buffer of that size and clears its part registry.
-3. Sender splits the file into MTU-sized chunks and broadcasts each one as a
-   `TRANSFER` packet.
+1. Sender broadcasts a `NEW_PACKET` announcing a random session id, the total
+   file size, the chunk size, the file's SHA-256, and its name.
+2. Each receiver latches that session, allocates a buffer, and clears its part
+   registry. Packets from any other session are ignored.
+3. Sender splits the file into chunk-sized pieces and broadcasts each one as a
+   `TRANSFER` packet, tagged with the session id.
 4. Sender broadcasts a `FINISH` packet when all chunks have been sent.
 5. Each receiver scans for missing chunks and requests them with `RESEND`
    packets.
 6. Sender retransmits each requested chunk.
 7. Steps 5–6 repeat until every chunk is received or the TTL expires.
+8. The receiver recomputes the SHA-256 of the reassembled file and only writes
+   it out if the digest matches; otherwise it reports corruption and fails.
 
 ## Packet Structure
 
-![Packet structure](https://www.gistrec.ru/wp-content/uploads/2019/01/Packets.png)
+All multi-byte fields are big-endian. Every packet carries the 32-bit session id
+so a receiver ignores traffic from a different (or restarted) sender.
+
+| Packet | Layout |
+| ------ | ------ |
+| `NEW_PACKET` | `"NEW_PACKET"` · version(2) · session(4) · file_size(4) · chunk_size(4) · sha256(32) · name_len(2) · name |
+| `TRANSFER` | `"TRANSFER"` · session(4) · part(4) · length(4) · data |
+| `FINISH` | `"FINISH"` · session(4) |
+| `RESEND` | `"RESEND"` · session(4) · part(4) |
 
 ## Limitations
 
 - The whole file is held in RAM on both sides. The receiver enforces a 4 GiB
-  cap on the announced file size; the sender is bounded only by available
-  memory.
-- No data integrity check beyond UDP's optional 16-bit checksum. If the
-  payload is corrupted in a way the checksum doesn't catch, the receiver will
-  silently produce a corrupted file.
+  cap on the announced file size; the sender rejects files that do not fit the
+  4-byte wire size field.
 - No authentication. Any host on the same LAN can send a `NEW_PACKET` and any
-  receiver bound to the chosen port will accept it.
+  receiver bound to the chosen port will accept it. The SHA-256 check catches
+  accidental corruption, not a deliberately crafted stream.
 - No encryption. The payload travels as plaintext UDP.
 
 ## Building from Source

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,6 +1,7 @@
 #include "Config.hpp"
 
 std::string fileName;
+bool        fileNameFromCli = false;
 
 int mtu      = 0;
 int ttl      = 0;

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -6,7 +6,8 @@
 #include <string>
 
 
-extern std::string fileName; // File Name to transfer or receive
+extern std::string fileName;     // File Name to transfer or receive
+extern bool        fileNameFromCli; // true if the user gave an explicit output name
 
 extern int mtu;     // Max packet size to send and receive
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -35,6 +35,7 @@ struct CliOptions {
     int         bind_port = 33333;
     int         delay_ms  = 20;
     std::string file;
+    bool        file_from_cli = false;  // true if the user named the file
     bool        use_broadcast = true;  // false when --to <ip> is given
     std::string target;                // destination IP for unicast
 };
@@ -135,12 +136,14 @@ bool collectOptions(const cxxopts::ParseResult& result, bool is_sender, CliOptio
 
     if (!validateNumericFlags(opt)) return false;
 
-    // send needs an explicit file; receive defaults to file.out.
-    if (is_sender && result.count("file") == 0) {
+    // send needs an explicit file; receive may take the name from the sender.
+    const bool has_file = (result.count("file") != 0);
+    if (is_sender && !has_file) {
         std::cerr << "Error: no file to send.\nUsage: filecast send <file>" << std::endl;
         return false;
     }
-    opt.file = (result.count("file") != 0) ? result["file"].as<std::string>() : "file.out";
+    opt.file          = has_file ? result["file"].as<std::string>() : std::string();
+    opt.file_from_cli = has_file;
 
     opt.use_broadcast = (result.count("to") == 0);
     opt.target = opt.use_broadcast ? std::string() : result["to"].as<std::string>();
@@ -267,11 +270,12 @@ int main(int argc, char* argv[]) {
     }
     #endif
 
-    mtu      = opt.mtu;
-    ttl      = opt.ttl;
-    ttl_max  = opt.ttl;
-    delay_ms = opt.delay_ms;
-    fileName = opt.file;
+    mtu             = opt.mtu;
+    ttl             = opt.ttl;
+    ttl_max         = opt.ttl;
+    delay_ms        = opt.delay_ms;
+    fileName        = opt.file;
+    fileNameFromCli = opt.file_from_cli;
 
     int rc = setupSocket(opt);
     if (rc != 0) {

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -102,8 +102,8 @@ std::string sanitizeName(const std::string& raw) {
 // Validate and store one TRANSFER packet. Returns true when a new part was
 // stored (shared by the main loop and the recovery loop so their validation
 // can never drift apart).
-bool handleTransfer(const char* buf, long length) {
-    if (length < static_cast<long>(TRANSFER_HEADER)) return false;
+bool handleTransfer(const char* buf, int64_t length) {
+    if (length < static_cast<int64_t>(TRANSFER_HEADER)) return false;
     if (Utils::getNumberFromBytes(buf + 8, 4) != session_id) return false;
 
     size_t part  = Utils::getNumberFromBytes(buf + 12, 4);
@@ -206,7 +206,7 @@ int checkParts() {
                                    &sender_address_length);
             if (length <= 0) break;                              // queue drained this round
             if (strncmp(buffer, "TRANSFER", 8) != 0) continue;   // e.g. our own RESEND
-            if (handleTransfer(buffer, static_cast<long>(length))) progressed = true;
+            if (handleTransfer(buffer, static_cast<int64_t>(length))) progressed = true;
         }
 
         // A new part refreshes ttl; a round with no progress counts down toward
@@ -258,8 +258,8 @@ bool announceValid(size_t announced, size_t chunk, int& exit_code) {
 // Parse and latch a NEW_PACKET. Sets exit_code and returns false if the caller
 // should return that code; returns true to continue the receive loop. buf may be
 // reallocated to fit the announced chunk size.
-bool handleNewPacket(char*& buf, size_t& bufcap, long length, int& exit_code) {
-    if (length < static_cast<long>(NEW_PACKET_FIXED)) return true;  // too short, ignore
+bool handleNewPacket(char*& buf, size_t& bufcap, int64_t length, int& exit_code) {
+    if (length < static_cast<int64_t>(NEW_PACKET_FIXED)) return true;  // too short, ignore
     if (Utils::getNumberFromBytes(buf + 10, 2) != PROTOCOL_VERSION) {
         std::cerr << "Warning: ignoring NEW_PACKET with unsupported protocol version" << std::endl;
         return true;
@@ -327,7 +327,7 @@ bool handleNewPacket(char*& buf, size_t& bufcap, long length, int& exit_code) {
 
 
 // Latch the "sender finished" state from a FINISH packet for our session.
-void handleFinish(const char* buf, long length, bool& finish) {
+void handleFinish(const char* buf, int64_t length, bool& finish) {
     if (length < 10) return;
     if (Utils::getNumberFromBytes(buf + 6, 4) != session_id) return;
     ttl = ttl_max;
@@ -379,16 +379,16 @@ int run() {
 
         if (strncmp(buffer, "NEW_PACKET", 10) == 0) {
             int exit_code = 0;
-            if (!handleNewPacket(buffer, bufcap, static_cast<long>(length), exit_code)) {
+            if (!handleNewPacket(buffer, bufcap, static_cast<int64_t>(length), exit_code)) {
                 delete[] buffer;
                 delete[] file;
                 file = nullptr;
                 return exit_code;
             }
         } else if (strncmp(buffer, "TRANSFER", 8) == 0 && file != nullptr) {
-            if (handleTransfer(buffer, static_cast<long>(length))) ttl = ttl_max;
+            if (handleTransfer(buffer, static_cast<int64_t>(length))) ttl = ttl_max;
         } else if (strncmp(buffer, "FINISH", 6) == 0) {
-            handleFinish(buffer, static_cast<long>(length), finish);
+            handleFinish(buffer, static_cast<int64_t>(length), finish);
         }
     }
     // ttl exhausted before FINISH: the transfer did not complete.

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -1,5 +1,6 @@
 #include "Utils.hpp"
 #include "Config.hpp"
+#include "Sha256.hpp"
 
 #include <iostream>
 #include <fstream>
@@ -7,6 +8,10 @@
 #include <chrono>
 #include <cstring>
 #include <cstdio>
+#include <cstdint>
+#include <cctype>
+#include <string>
+#include <algorithm>
 #include <vector>
 #include <set>
 
@@ -20,6 +25,14 @@ namespace Receiver {
 // only if you know the receiver has enough memory.
 constexpr size_t MAX_FILE_LENGTH = 4ULL * 1024 * 1024 * 1024; // 4 GiB
 
+// Wire protocol the receiver speaks; a NEW_PACKET with any other version is
+// rejected rather than misparsed.
+constexpr uint16_t PROTOCOL_VERSION = 2;
+
+// NEW_PACKET v2 fixed header (see Sender.cpp) and the TRANSFER header size.
+constexpr size_t NEW_PACKET_FIXED = 58;
+constexpr size_t TRANSFER_HEADER  = 20;
+
 // Session the receiver is currently bound to. The sender stamps a random id into
 // every packet; we latch it from the first NEW_PACKET and then reject packets
 // from any other session, so a second sender (or a restarted one) cannot mix a
@@ -27,21 +40,126 @@ constexpr size_t MAX_FILE_LENGTH = 4ULL * 1024 * 1024 * 1024; // 4 GiB
 size_t session_id   = 0;
 bool   have_session = false;
 
+// Chunk size (the sender's MTU) announced in NEW_PACKET. The receiver slices the
+// file by this value rather than its own --mtu, so a sender/receiver MTU
+// mismatch no longer live-locks the transfer.
+size_t chunk_size = 0;
+
+// SHA-256 of the whole file, announced by the sender and checked after reassembly.
+uint8_t expected_hash[32] = {0};
+
+// File name announced by the sender, used when the user did not name the output.
+std::string announced_name;
+
 /**
  * List of received parts
  */
 std::set<size_t> parts;
+
+size_t totalParts() {
+    return (file_length + chunk_size - 1) / chunk_size;
+}
 
 /**
  * Get empty parts
  */
 std::vector<size_t> getEmptyParts() {
     std::vector<size_t> result;
-    size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
+    size_t total_parts = totalParts();
     for (size_t i = 0; i < total_parts; i++) {
         if (parts.find(i) == parts.end()) result.push_back(i);
     }
     return result;
+}
+
+// A Windows reserved device name (CON, NUL, COM1..9, LPT1..9, ...), optionally
+// with an extension. Opening such a name writes to a device, not a file.
+bool isReservedDeviceName(const std::string& name) {
+    std::string stem = name.substr(0, name.find('.'));
+    std::transform(stem.begin(), stem.end(), stem.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    if (stem == "CON" || stem == "PRN" || stem == "AUX" || stem == "NUL") return true;
+    if (stem.size() == 4 && (stem.compare(0, 3, "COM") == 0 || stem.compare(0, 3, "LPT") == 0) &&
+        stem[3] >= '1' && stem[3] <= '9') {
+        return true;
+    }
+    return false;
+}
+
+// Keep only the base name of a sender-supplied path and refuse anything that
+// could escape the working directory, so a hostile sender cannot make us write
+// elsewhere. Besides '/' and '\\', a ':' on Windows introduces a drive-relative
+// path or an alternate data stream, and reserved names map to devices.
+std::string sanitizeName(const std::string& raw) {
+    size_t slash = raw.find_last_of("/\\");
+    std::string name = (slash == std::string::npos) ? raw : raw.substr(slash + 1);
+    if (name.empty() || name == "." || name == "..") return "file.out";
+    if (name.find(':') != std::string::npos) return "file.out";
+    if (isReservedDeviceName(name)) return "file.out";
+    return name;
+}
+
+// Validate and store one TRANSFER packet. Returns true when a new part was
+// stored (shared by the main loop and the recovery loop so their validation
+// can never drift apart).
+bool handleTransfer(const char* buf, long length) {
+    if (length < static_cast<long>(TRANSFER_HEADER)) return false;
+    if (Utils::getNumberFromBytes(buf + 8, 4) != session_id) return false;
+
+    size_t part  = Utils::getNumberFromBytes(buf + 12, 4);
+    size_t size  = Utils::getNumberFromBytes(buf + 16, 4);
+    size_t total = totalParts();
+    if (part >= total) return false;
+    if (parts.find(part) != parts.end()) return false;
+
+    // For non-final parts size must equal the chunk size; for the final part it
+    // must equal the remaining bytes. Anything else is malformed and would
+    // either silently zero-pad data or write past the file buffer.
+    size_t expected = (part + 1 < total)
+        ? chunk_size
+        : (file_length - part * chunk_size);
+    if (size != expected) return false;
+    if (static_cast<size_t>(length) < size + TRANSFER_HEADER) return false;
+
+    parts.insert(part);
+    memcpy(file + part * chunk_size, buf + TRANSFER_HEADER, size);
+    std::cout << "Receive " << part << " part with size " << size << std::endl;
+    return true;
+}
+
+// Verify the reassembled file against the announced digest and write it out.
+// Returns a process exit code.
+int verifyAndWrite() {
+    uint8_t got[32];
+    Sha256::hash(file, file_length, got);
+    if (memcmp(got, expected_hash, 32) != 0) {
+        std::cerr << "Error: checksum mismatch — received file is corrupt" << std::endl;
+        delete[] file;
+        file = nullptr;
+        return 2;
+    }
+    std::cout << "Ok: sha256 verified " << Sha256::hex(got) << std::endl;
+
+    std::ofstream output(fileName, std::ofstream::binary);
+    if (!output.is_open()) {
+        std::cerr << "Error: Can't open output file " << fileName << std::endl;
+        delete[] file;
+        file = nullptr;
+        return 2;
+    }
+    output.write(file, static_cast<std::streamsize>(file_length));
+    if (!output) {
+        std::cerr << "Error: Failed to write output file " << fileName << std::endl;
+        delete[] file;
+        file = nullptr;
+        return 2;
+    }
+    output.close();
+    std::cout << "File successfully received as " << fileName << std::endl;
+
+    delete[] file;
+    file = nullptr;
+    return 0;
 }
 
 /**
@@ -50,7 +168,8 @@ std::vector<size_t> getEmptyParts() {
  */
 // Returns a process exit code: 0 on success, non-zero on failure.
 int checkParts() {
-    char* buffer = new (std::nothrow) char[2 * mtu];
+    size_t bufcap = std::max(chunk_size + TRANSFER_HEADER, static_cast<size_t>(2048));
+    char* buffer = new (std::nothrow) char[bufcap];
     if (!buffer) {
         std::cerr << "Error: Can't allocate receive buffer" << std::endl;
         delete[] file;
@@ -82,31 +201,12 @@ int checkParts() {
 
         bool progressed = false;
         while (true) {
-            auto length = recvfrom(_socket, buffer, 2 * mtu, 0,
+            auto length = recvfrom(_socket, buffer, static_cast<int>(bufcap), 0,
                                    reinterpret_cast<sockaddr*>(&sender_address),
                                    &sender_address_length);
             if (length <= 0) break;                              // queue drained this round
             if (strncmp(buffer, "TRANSFER", 8) != 0) continue;   // e.g. our own RESEND
-            if (static_cast<size_t>(length) < 20) continue;
-            if (Utils::getNumberFromBytes(buffer + 8, 4) != session_id) continue;
-
-            size_t part        = Utils::getNumberFromBytes(buffer + 12, 4);
-            size_t size        = Utils::getNumberFromBytes(buffer + 16, 4);
-            size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
-
-            // For non-final parts size must equal MTU; for the final part it must
-            // equal the remaining bytes. Anything else is malformed and would
-            // either silently zero-pad data or write past the file buffer.
-            size_t expected = (part + 1 < total_parts)
-                ? static_cast<size_t>(mtu)
-                : (file_length - part * static_cast<size_t>(mtu));
-            if (part < total_parts && parts.find(part) == parts.end() &&
-                size == expected && static_cast<size_t>(length) >= size + 20) {
-                parts.insert(part);
-                memcpy(file + part * static_cast<size_t>(mtu), buffer + 20, size);
-                std::cout << "Receive " << part << " part with size " << size << std::endl;
-                progressed = true;
-            }
+            if (handleTransfer(buffer, static_cast<long>(length))) progressed = true;
         }
 
         // A new part refreshes ttl; a round with no progress counts down toward
@@ -127,34 +227,122 @@ int checkParts() {
         return 2;
     }
 
-    std::ofstream output(fileName, std::ofstream::binary);
-    if (!output.is_open()) {
-        std::cerr << "Error: Can't open output file " << fileName << std::endl;
-        delete[] file;
-        file = nullptr;
-        return 2;
-    }
-    output.write(file, static_cast<std::streamsize>(file_length));
-    if (!output) {
-        std::cerr << "Error: Failed to write output file " << fileName << std::endl;
-        delete[] file;
-        file = nullptr;
-        return 2;
-    }
-    output.close();
-    std::cout << "File successfully received" << std::endl;
-
-    delete[] file;
-    file = nullptr;
-    return 0;
+    return verifyAndWrite();
 }
 
+// Range-check the announced sizes. Prints and sets exit_code on failure.
+bool announceValid(size_t announced, size_t chunk, int& exit_code) {
+    if (announced == 0) {
+        std::cerr << "Error: Sender announced empty file" << std::endl;
+        exit_code = 2;
+        return false;
+    }
+    if (announced > MAX_FILE_LENGTH) {
+        std::cerr << "Error: Sender announced file size " << announced
+                  << " bytes, exceeds limit of " << MAX_FILE_LENGTH << std::endl;
+        exit_code = 2;
+        return false;
+    }
+    // Chunk size must be in the sender's valid --mtu range. The lower bound
+    // matters for safety: parts = file_length / chunk_size, so a forged chunk
+    // size of 1 would make getEmptyParts() build a multi-billion-entry vector
+    // and OOM/crash the receiver from two tiny packets.
+    if (chunk < 64 || chunk > 65507) {
+        std::cerr << "Error: Sender announced invalid chunk size " << chunk << std::endl;
+        exit_code = 2;
+        return false;
+    }
+    return true;
+}
+
+// Parse and latch a NEW_PACKET. Sets exit_code and returns false if the caller
+// should return that code; returns true to continue the receive loop. buf may be
+// reallocated to fit the announced chunk size.
+bool handleNewPacket(char*& buf, size_t& bufcap, long length, int& exit_code) {
+    if (length < static_cast<long>(NEW_PACKET_FIXED)) return true;  // too short, ignore
+    if (Utils::getNumberFromBytes(buf + 10, 2) != PROTOCOL_VERSION) {
+        std::cerr << "Warning: ignoring NEW_PACKET with unsupported protocol version" << std::endl;
+        return true;
+    }
+
+    size_t incoming_sid = Utils::getNumberFromBytes(buf + 12, 4);
+    // A NEW_PACKET from a different session (a second sender, or our own sender
+    // restarted) must not clobber the transfer already in progress.
+    if (have_session && incoming_sid != session_id) {
+        std::cerr << "Warning: ignoring NEW_PACKET from another sender session" << std::endl;
+        return true;
+    }
+
+    size_t announced   = Utils::getNumberFromBytes(buf + 16, 4);
+    size_t incoming_cs = Utils::getNumberFromBytes(buf + 20, 4);
+    size_t name_len    = Utils::getNumberFromBytes(buf + 56, 2);
+    if (static_cast<size_t>(length) < NEW_PACKET_FIXED + name_len) return true;  // truncated
+
+    // Only a recognised packet from our sender refreshes ttl. Unrecognised
+    // traffic (stray broadcasts, other receivers' RESENDs, garbage) deliberately
+    // does not, so the timeout stays reachable and a hostile or noisy host cannot
+    // keep the receiver alive forever.
+    ttl = ttl_max;
+
+    if (!announceValid(announced, incoming_cs, exit_code)) return false;
+
+    // Duplicate retransmission of the same NEW_PACKET: keep accumulated parts.
+    if (file != nullptr && announced == file_length && incoming_cs == chunk_size) return true;
+
+    session_id   = incoming_sid;
+    have_session = true;
+    file_length  = announced;
+    chunk_size   = incoming_cs;
+    memcpy(expected_hash, buf + 24, 32);
+    announced_name = sanitizeName(std::string(buf + NEW_PACKET_FIXED, name_len));
+    if (!fileNameFromCli) fileName = announced_name;
+
+    // Grow the receive buffer if a TRANSFER for this chunk size would not fit.
+    size_t need = chunk_size + TRANSFER_HEADER;
+    if (need > bufcap) {
+        delete[] buf;
+        bufcap = need;
+        buf = new (std::nothrow) char[bufcap];
+        if (!buf) {
+            std::cerr << "Error: Can't allocate receive buffer" << std::endl;
+            exit_code = 1;
+            return false;
+        }
+    }
+
+    delete[] file;
+    parts.clear();
+    file = new (std::nothrow) char[file_length];
+    if (!file) {
+        std::cerr << "Error: Can't allocate " << file_length << " bytes" << std::endl;
+        exit_code = 1;
+        return false;
+    }
+
+    std::cout << "Receive information about new file: " << fileName
+              << " (" << file_length << " bytes)" << std::endl;
+    std::cout << "Number of parts: " << totalParts() << std::endl;
+    return true;
+}
+
+
+// Latch the "sender finished" state from a FINISH packet for our session.
+void handleFinish(const char* buf, long length, bool& finish) {
+    if (length < 10) return;
+    if (Utils::getNumberFromBytes(buf + 6, 4) != session_id) return;
+    ttl = ttl_max;
+    if (!finish) {
+        std::cout << "Server finished transferring" << std::endl;
+        finish = true;
+    }
+}
 
 // Returns a process exit code: 0 on success, non-zero on failure.
 int run() {
     bool finish = false; // Sender finished transferring
 
-    char* buffer = new (std::nothrow) char[2 * mtu];
+    size_t bufcap = std::max(static_cast<size_t>(2 * mtu), static_cast<size_t>(2048));
+    char* buffer = new (std::nothrow) char[bufcap];
     if (!buffer) {
         std::cerr << "Error: Can't allocate receive buffer" << std::endl;
         return 1;
@@ -173,7 +361,7 @@ int run() {
             return 2;
         }
 
-        auto length = recvfrom(_socket, buffer, 2 * mtu, 0,
+        auto length = recvfrom(_socket, buffer, static_cast<int>(bufcap), 0,
                                reinterpret_cast<sockaddr*>(&server_address),
                                &server_address_length);
 
@@ -189,84 +377,18 @@ int run() {
             continue;
         }
 
-        if (strncmp(buffer, "NEW_PACKET", 10) == 0 && static_cast<size_t>(length) >= 18) {
-            size_t incoming_sid = Utils::getNumberFromBytes(buffer + 10, 4);
-            // A NEW_PACKET from a different session (a second sender, or our own
-            // sender restarted) must not clobber the transfer already in progress.
-            if (have_session && incoming_sid != session_id) {
-                std::cerr << "Warning: ignoring NEW_PACKET from another sender session" << std::endl;
-                continue;
-            }
-            // Only a recognised packet from our sender refreshes ttl. Unrecognised
-            // traffic (stray broadcasts, other receivers' RESENDs, garbage)
-            // deliberately does not, so the timeout stays reachable and a hostile
-            // or noisy host cannot keep the receiver alive forever.
-            ttl = ttl_max;
-            size_t announced = Utils::getNumberFromBytes(buffer + 14, 4);
-            if (announced == 0) {
-                std::cerr << "Error: Sender announced empty file" << std::endl;
+        if (strncmp(buffer, "NEW_PACKET", 10) == 0) {
+            int exit_code = 0;
+            if (!handleNewPacket(buffer, bufcap, static_cast<long>(length), exit_code)) {
                 delete[] buffer;
-                return 2;
+                delete[] file;
+                file = nullptr;
+                return exit_code;
             }
-            if (announced > MAX_FILE_LENGTH) {
-                std::cerr << "Error: Sender announced file size " << announced
-                          << " bytes, exceeds limit of " << MAX_FILE_LENGTH << std::endl;
-                delete[] buffer;
-                return 2;
-            }
-
-            // Sender retransmits NEW_PACKET a few times for robustness; if we
-            // already have a buffer for the same size, treat this as a
-            // duplicate and keep accumulated parts.
-            if (file != nullptr && announced == file_length) continue;
-
-            session_id   = incoming_sid;
-            have_session = true;
-            file_length  = announced;
-
-            delete[] file;
-            parts.clear();
-            file = new (std::nothrow) char[file_length];
-            if (!file) {
-                std::cerr << "Error: Can't allocate " << file_length << " bytes" << std::endl;
-                delete[] buffer;
-                return 1;
-            }
-            memset(file, 0, file_length);
-
-            std::cout << "Receive information about new file size: " << file_length << std::endl;
-            std::cout << "Number of parts: " << (file_length + mtu - 1) / mtu << std::endl;
         } else if (strncmp(buffer, "TRANSFER", 8) == 0 && file != nullptr) {
-            if (static_cast<size_t>(length) < 20) continue;
-            if (Utils::getNumberFromBytes(buffer + 8, 4) != session_id) continue;
-            size_t part        = Utils::getNumberFromBytes(buffer + 12, 4); // Read section "index"
-            size_t size        = Utils::getNumberFromBytes(buffer + 16, 4); // Read section "size"
-            size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
-
-            if (part >= total_parts) continue;
-            // For non-final parts size must equal MTU; for the final part it must
-            // equal the remaining bytes. Anything else is malformed and would
-            // either silently zero-pad data or write past the file buffer.
-            size_t expected = (part + 1 < total_parts)
-                ? static_cast<size_t>(mtu)
-                : (file_length - part * static_cast<size_t>(mtu));
-            if (size != expected) continue;
-            if (static_cast<size_t>(length) < size + 20) continue;
-
-            ttl = ttl_max;
-            parts.insert(part);
-            std::cout << "Receive " << part << " part with size " << size << std::endl;
-
-            memcpy(file + part * static_cast<size_t>(mtu), buffer + 20, size);
+            if (handleTransfer(buffer, static_cast<long>(length))) ttl = ttl_max;
         } else if (strncmp(buffer, "FINISH", 6) == 0) {
-            if (static_cast<size_t>(length) < 10) continue;
-            if (Utils::getNumberFromBytes(buffer + 6, 4) != session_id) continue;
-            ttl = ttl_max;
-            // If receiver didn't receive a finish message
-            if (!finish) {
-                std::cout << "Server finished transferring" << std::endl;
-                finish = true;
-            }
+            handleFinish(buffer, static_cast<long>(length), finish);
         }
     }
     // ttl exhausted before FINISH: the transfer did not complete.

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -52,7 +52,7 @@ std::string baseName(const std::string& path) {
  * It is necessary to limit the sending of the same parts for a while
  * This container contains part number and time when the part was sent
  */
-std::map<size_t, long> sent_part;
+std::map<size_t, int64_t> sent_part;
 
 void sendPart(size_t part_index) {
     size_t offset        = part_index * static_cast<size_t>(mtu);
@@ -172,7 +172,7 @@ void sendNewPacket() {
 
 // Serve RESEND requests until ttl expires, re-announcing FINISH periodically.
 void serveResends(size_t total_parts) {
-    long lastFinishSendTime = 0;
+    int64_t lastFinishSendTime = 0;
 
     SOCKADDR_IN sender_address;
     memset(&sender_address, 0, sizeof(sender_address));
@@ -203,7 +203,7 @@ void serveResends(size_t total_parts) {
         if (part >= total_parts) continue;
 
         auto epoch    = std::chrono::system_clock::now().time_since_epoch();
-        long duration = std::chrono::duration_cast<std::chrono::seconds>(epoch).count();
+        int64_t duration = std::chrono::duration_cast<std::chrono::seconds>(epoch).count();
 
         ttl = ttl_max;
 

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -1,5 +1,6 @@
 #include "Utils.hpp"
 #include "Config.hpp"
+#include "Sha256.hpp"
 
 #include <iostream>
 #include <fstream>
@@ -8,6 +9,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cstdint>
+#include <string>
 #include <map>
 #include <random>
 
@@ -19,6 +21,15 @@ namespace Sender {
 // TRANSFER header: "TRANSFER"(8) + session id(4) + part number(4) + length(4).
 constexpr int HEADER_SIZE = 20;
 
+// Wire protocol version, announced in NEW_PACKET so a receiver can reject a
+// sender it does not understand instead of misparsing the stream.
+constexpr uint16_t PROTOCOL_VERSION = 2;
+
+// NEW_PACKET v2 fixed header, before the variable-length file name:
+// "NEW_PACKET"(10) + version(2) + session(4) + file_length(4) + chunk_size(4)
+// + sha256(32) + name_len(2) = 58 bytes.
+constexpr int NEW_PACKET_FIXED = 58;
+
 // Random per-transfer id, generated in run() and stamped into every packet so a
 // receiver can reject packets from a different sender (a second concurrent
 // sender, or a restart) instead of silently mixing two files into one buffer.
@@ -28,6 +39,13 @@ uint32_t session_id = 0;
 // does not fit into 32 bits would be silently truncated on the wire (a 4 GiB
 // file would be announced as 0). Reject such files up front instead.
 constexpr size_t MAX_WIRE_FILE_LENGTH = 0xFFFFFFFFULL;
+
+// Strip any directory part; only the base name travels on the wire so the
+// receiver cannot be told to write outside its working directory.
+std::string baseName(const std::string& path) {
+    size_t slash = path.find_last_of("/\\");
+    return (slash == std::string::npos) ? path : path.substr(slash + 1);
+}
 
 /**
  * Since server may receive many requests for sending some part
@@ -56,17 +74,22 @@ void sendPart(size_t part_index) {
     std::cout << "Part " << part_index << " with size " << packet_length << " was sent" << std::endl;
 }
 
-// Returns a process exit code: 0 on success, non-zero on failure.
-int run() {
-    buffer = new char[2 * mtu];
+void sendFinish() {
+    snprintf(buffer, 7, "FINISH");
+    Utils::writeBytesFromNumber(buffer + 6, session_id, 4);
+    if (sendto(_socket, buffer, 10, 0,
+               reinterpret_cast<sockaddr*>(&broadcast_address),
+               sizeof(broadcast_address)) < 0) {
+        std::cerr << "Warning: Failed to send FINISH" << std::endl;
+    }
+}
 
+// Load the whole file into the global `file` buffer. Returns 0 on success, or
+// an error code after cleaning up the file buffer.
+int loadFileIntoMemory() {
     std::ifstream input(fileName, std::ios::binary);
     if (!input.is_open()) {
         std::cerr << "Error: Can't open file " << fileName << std::endl;
-        delete[] buffer;
-        buffer = nullptr;
-        CLOSE_SOCKET(_socket);
-        CLEANUP_NETWORK();
         return 1;
     }
 
@@ -74,10 +97,6 @@ int run() {
     auto end_pos = input.tellg();
     if (end_pos < 0) {
         std::cerr << "Error: Can't determine file size" << std::endl;
-        delete[] buffer;
-        buffer = nullptr;
-        CLOSE_SOCKET(_socket);
-        CLEANUP_NETWORK();
         return 1;
     }
     file_length = static_cast<size_t>(end_pos);
@@ -85,56 +104,61 @@ int run() {
 
     if (file_length == 0) {
         std::cerr << "Error: File is empty" << std::endl;
-        delete[] buffer;
-        buffer = nullptr;
-        CLOSE_SOCKET(_socket);
-        CLEANUP_NETWORK();
         return 1;
     }
-
     if (file_length > MAX_WIRE_FILE_LENGTH) {
         std::cerr << "Error: File is too large (" << file_length
                   << " bytes); the 4-byte wire format supports at most "
                   << MAX_WIRE_FILE_LENGTH << " bytes" << std::endl;
-        delete[] buffer;
-        buffer = nullptr;
-        CLOSE_SOCKET(_socket);
-        CLEANUP_NETWORK();
         return 1;
     }
 
     file = new (std::nothrow) char[file_length];
     if (!file) {
         std::cerr << "Error: Can't allocate " << file_length << " bytes" << std::endl;
-        delete[] buffer;
-        buffer = nullptr;
-        CLOSE_SOCKET(_socket);
-        CLEANUP_NETWORK();
         return 1;
     }
     input.read(file, static_cast<std::streamsize>(file_length));
     if (static_cast<size_t>(input.gcount()) != file_length) {
         std::cerr << "Error: Could not read entire file" << std::endl;
-        delete[] file;   file   = nullptr;
-        delete[] buffer; buffer = nullptr;
-        CLOSE_SOCKET(_socket);
-        CLEANUP_NETWORK();
+        delete[] file;
+        file = nullptr;
         return 1;
     }
+    return 0;
+}
 
-    std::cout << "Ok: File successfully copied to RAM" << std::endl;
-
+// Build and broadcast NEW_PACKET (retransmitted a few times, since a single
+// drop would strand every receiver and there is no RESEND for it).
+void sendNewPacket() {
     std::random_device rd;
     session_id = static_cast<uint32_t>(rd());
 
+    // Digest of the whole file; the receiver verifies against it after reassembly.
+    uint8_t file_hash[32];
+    Sha256::hash(file, file_length, file_hash);
+    std::cout << "Ok: sha256 " << Sha256::hex(file_hash) << std::endl;
+
+    // Name the receiver saves under unless it was given an explicit output path.
+    // Clamp so the whole NEW_PACKET fits the send buffer (2 * mtu) and the length
+    // field (a byte count well under 2^16).
+    std::string name = baseName(fileName);
+    size_t max_name = static_cast<size_t>(2 * mtu) - NEW_PACKET_FIXED;
+    if (max_name > 255) max_name = 255;
+    if (name.size() > max_name) name.resize(max_name);
+
     snprintf(buffer, 11, "NEW_PACKET");
-    Utils::writeBytesFromNumber(buffer + 10, session_id, 4);
-    Utils::writeBytesFromNumber(buffer + 14, file_length, 4);
-    // NEW_PACKET is sent only once (no RESEND mechanism for it), so a single
-    // dropped packet would strand every receiver. Retransmit a few times to
-    // make the start of the transfer robust to typical LAN loss.
+    Utils::writeBytesFromNumber(buffer + 10, PROTOCOL_VERSION,          2);
+    Utils::writeBytesFromNumber(buffer + 12, session_id,               4);
+    Utils::writeBytesFromNumber(buffer + 16, file_length,              4);
+    Utils::writeBytesFromNumber(buffer + 20, static_cast<size_t>(mtu), 4);
+    memcpy(buffer + 24, file_hash, 32);
+    Utils::writeBytesFromNumber(buffer + 56, name.size(),              2);
+    memcpy(buffer + NEW_PACKET_FIXED, name.data(), name.size());
+    int new_packet_len = NEW_PACKET_FIXED + static_cast<int>(name.size());
+
     for (int i = 0; i < 3; ++i) {
-        if (sendto(_socket, buffer, 18, 0,
+        if (sendto(_socket, buffer, new_packet_len, 0,
                    reinterpret_cast<sockaddr*>(&broadcast_address),
                    sizeof(broadcast_address)) < 0) {
             std::cerr << "Warning: Failed to send NEW_PACKET" << std::endl;
@@ -143,27 +167,12 @@ int run() {
             std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
         }
     }
-
     std::cout << "Ok: Sent information about new file with size " << file_length << std::endl;
+}
 
-    size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
-
-    for (size_t part_index = 0; part_index < total_parts; ++part_index) {
-        sent_part.insert({ part_index, 0 });
-        sendPart(part_index);
-        if (delay_ms > 0) std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
-    }
-
-    snprintf(buffer, 7, "FINISH");
-    Utils::writeBytesFromNumber(buffer + 6, session_id, 4);
-    if (sendto(_socket, buffer, 10, 0,
-               reinterpret_cast<sockaddr*>(&broadcast_address),
-               sizeof(broadcast_address)) < 0) {
-        std::cerr << "Warning: Failed to send FINISH" << std::endl;
-    }
-    std::cout << "Ok: File transfer complete" << std::endl;
-
-    long lastFinishSendTime = 0; // Last time, when sender sent file transfer completion information
+// Serve RESEND requests until ttl expires, re-announcing FINISH periodically.
+void serveResends(size_t total_parts) {
+    long lastFinishSendTime = 0;
 
     SOCKADDR_IN sender_address;
     memset(&sender_address, 0, sizeof(sender_address));
@@ -181,50 +190,62 @@ int run() {
         // No incoming requests for a while - resend FINISH and decrement ttl.
         if (result <= 0) {
             ttl--;
-            snprintf(buffer, 7, "FINISH");
-            Utils::writeBytesFromNumber(buffer + 6, session_id, 4);
-            if (sendto(_socket, buffer, 10, 0,
-                       reinterpret_cast<sockaddr*>(&broadcast_address),
-                       sizeof(broadcast_address)) < 0) {
-                std::cerr << "Warning: Failed to send FINISH" << std::endl;
-            }
+            sendFinish();
             continue;
         }
 
-        if (strncmp(buffer, "RESEND", 6) == 0) {
-            // Ignore RESENDs shorter than the header or belonging to a different
-            // session (another sender's receivers requesting their own transfer).
-            if (result < 14) continue;
-            if (Utils::getNumberFromBytes(buffer + 6, 4) != session_id) continue;
-            size_t part = Utils::getNumberFromBytes(buffer + 10, 4);
+        if (strncmp(buffer, "RESEND", 6) != 0) continue;
+        // Ignore RESENDs shorter than the header or belonging to a different
+        // session (another sender's receivers requesting their own transfer).
+        if (result < 14) continue;
+        if (Utils::getNumberFromBytes(buffer + 6, 4) != session_id) continue;
+        size_t part = Utils::getNumberFromBytes(buffer + 10, 4);
+        if (part >= total_parts) continue;
 
-            if (part >= total_parts) continue;
+        auto epoch    = std::chrono::system_clock::now().time_since_epoch();
+        long duration = std::chrono::duration_cast<std::chrono::seconds>(epoch).count();
 
-            auto now      = std::chrono::system_clock::now();
-            auto epoch    = now.time_since_epoch();
-            long duration = std::chrono::duration_cast<std::chrono::seconds>(epoch).count();
+        ttl = ttl_max;
 
-            ttl = ttl_max;
-
-            if (duration - sent_part[part] >= 1) {
-                sent_part[part] = duration;
-                std::cout << "Client requested part of file with index " << part << std::endl;
-                sendPart(part);
-            }
-
-            // sending file completion information every second
-            if (duration - lastFinishSendTime >= 1) {
-                lastFinishSendTime = duration;
-                snprintf(buffer, 7, "FINISH");
-                Utils::writeBytesFromNumber(buffer + 6, session_id, 4);
-                if (sendto(_socket, buffer, 10, 0,
-                           reinterpret_cast<sockaddr*>(&broadcast_address),
-                           sizeof(broadcast_address)) < 0) {
-                    std::cerr << "Warning: Failed to send FINISH" << std::endl;
-                }
-            }
+        if (duration - sent_part[part] >= 1) {
+            sent_part[part] = duration;
+            std::cout << "Client requested part of file with index " << part << std::endl;
+            sendPart(part);
+        }
+        // Re-announce completion at most once a second.
+        if (duration - lastFinishSendTime >= 1) {
+            lastFinishSendTime = duration;
+            sendFinish();
         }
     }
+}
+
+// Returns a process exit code: 0 on success, non-zero on failure.
+int run() {
+    buffer = new char[2 * mtu];
+
+    if (loadFileIntoMemory() != 0) {
+        delete[] buffer;
+        buffer = nullptr;
+        CLOSE_SOCKET(_socket);
+        CLEANUP_NETWORK();
+        return 1;
+    }
+    std::cout << "Ok: File successfully copied to RAM" << std::endl;
+
+    sendNewPacket();
+
+    size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
+    for (size_t part_index = 0; part_index < total_parts; ++part_index) {
+        sent_part.insert({ part_index, 0 });
+        sendPart(part_index);
+        if (delay_ms > 0) std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+    }
+
+    sendFinish();
+    std::cout << "Ok: File transfer complete" << std::endl;
+
+    serveResends(total_parts);
     std::cout << "Ok: Transfer session ended" << std::endl;
 
     delete[] buffer;

--- a/src/Sha256.hpp
+++ b/src/Sha256.hpp
@@ -1,0 +1,137 @@
+#ifndef FILECAST_SHA256_H
+#define FILECAST_SHA256_H
+
+// Small self-contained SHA-256 (public-domain algorithm, FIPS 180-4). Used to
+// verify the integrity of a received file against the digest the sender puts in
+// NEW_PACKET. Header-only so it stays dependency-free like the rest of filecast.
+
+#include <cstdint>
+#include <cstddef>
+#include <cstring>
+#include <string>
+
+namespace Sha256 {
+
+struct Ctx {
+    uint32_t state[8];
+    uint64_t bitlen;
+    uint8_t  data[64];
+    uint32_t datalen;
+};
+
+inline uint32_t rotr(uint32_t x, uint32_t n) {
+    return (x >> n) | (x << (32 - n));
+}
+
+inline void transform(Ctx& c, const uint8_t* d) {
+    static const uint32_t k[64] = {
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+        0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+        0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+        0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+        0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+        0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+        0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+        0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+    };
+
+    uint32_t m[64];
+    for (int i = 0, j = 0; i < 16; ++i, j += 4) {
+        m[i] = (static_cast<uint32_t>(d[j]) << 24) | (static_cast<uint32_t>(d[j + 1]) << 16) |
+               (static_cast<uint32_t>(d[j + 2]) << 8) | static_cast<uint32_t>(d[j + 3]);
+    }
+    for (int i = 16; i < 64; ++i) {
+        uint32_t s0 = rotr(m[i - 15], 7) ^ rotr(m[i - 15], 18) ^ (m[i - 15] >> 3);
+        uint32_t s1 = rotr(m[i - 2], 17) ^ rotr(m[i - 2], 19) ^ (m[i - 2] >> 10);
+        m[i] = m[i - 16] + s0 + m[i - 7] + s1;
+    }
+
+    uint32_t a = c.state[0], b = c.state[1], cc = c.state[2], dd = c.state[3];
+    uint32_t e = c.state[4], f = c.state[5], g = c.state[6], h = c.state[7];
+
+    for (int i = 0; i < 64; ++i) {
+        uint32_t S1  = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+        uint32_t ch  = (e & f) ^ ((~e) & g);
+        uint32_t t1  = h + S1 + ch + k[i] + m[i];
+        uint32_t S0  = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+        uint32_t maj = (a & b) ^ (a & cc) ^ (b & cc);
+        uint32_t t2  = S0 + maj;
+        h = g; g = f; f = e; e = dd + t1;
+        dd = cc; cc = b; b = a; a = t1 + t2;
+    }
+
+    c.state[0] += a; c.state[1] += b; c.state[2] += cc; c.state[3] += dd;
+    c.state[4] += e; c.state[5] += f; c.state[6] += g;  c.state[7] += h;
+}
+
+inline void init(Ctx& c) {
+    c.datalen = 0;
+    c.bitlen  = 0;
+    c.state[0] = 0x6a09e667; c.state[1] = 0xbb67ae85;
+    c.state[2] = 0x3c6ef372; c.state[3] = 0xa54ff53a;
+    c.state[4] = 0x510e527f; c.state[5] = 0x9b05688c;
+    c.state[6] = 0x1f83d9ab; c.state[7] = 0x5be0cd19;
+}
+
+inline void update(Ctx& c, const uint8_t* data, size_t len) {
+    for (size_t i = 0; i < len; ++i) {
+        c.data[c.datalen++] = data[i];
+        if (c.datalen == 64) {
+            transform(c, c.data);
+            c.bitlen += 512;
+            c.datalen = 0;
+        }
+    }
+}
+
+inline void finish(Ctx& c, uint8_t hash[32]) {
+    uint32_t i = c.datalen;
+    if (c.datalen < 56) {
+        c.data[i++] = 0x80;
+        while (i < 56) c.data[i++] = 0x00;
+    } else {
+        c.data[i++] = 0x80;
+        while (i < 64) c.data[i++] = 0x00;
+        transform(c, c.data);
+        std::memset(c.data, 0, 56);
+    }
+
+    c.bitlen += static_cast<uint64_t>(c.datalen) * 8;
+    for (int j = 0; j < 8; ++j) {
+        c.data[63 - j] = static_cast<uint8_t>(c.bitlen >> (j * 8));
+    }
+    transform(c, c.data);
+
+    for (uint32_t j = 0; j < 4; ++j) {
+        for (int s = 0; s < 8; ++s) {
+            hash[j + s * 4] = static_cast<uint8_t>((c.state[s] >> (24 - j * 8)) & 0xff);
+        }
+    }
+}
+
+// Compute the SHA-256 digest of `len` bytes into out[32].
+inline void hash(const void* data, size_t len, uint8_t out[32]) {
+    Ctx c;
+    init(c);
+    update(c, static_cast<const uint8_t*>(data), len);
+    finish(c, out);
+}
+
+// 64-character lowercase hex of a 32-byte digest.
+inline std::string hex(const uint8_t digest[32]) {
+    static const char* h = "0123456789abcdef";
+    std::string s;
+    s.reserve(64);
+    for (int i = 0; i < 32; ++i) {
+        s += h[(digest[i] >> 4) & 0xf];
+        s += h[digest[i] & 0xf];
+    }
+    return s;
+}
+
+}  // namespace Sha256
+
+#endif  // FILECAST_SHA256_H

--- a/tests/Tests.cpp
+++ b/tests/Tests.cpp
@@ -1,6 +1,10 @@
 #include <gtest/gtest.h>
 
 #include "../src/Utils.hpp"
+#include "../src/Sha256.hpp"
+
+#include <string>
+#include <cstring>
 
 class BytesConverter : public ::testing::TestWithParam<std::tuple<size_t, int>> {
 public:
@@ -27,6 +31,36 @@ TEST_P(BytesConverter, getIntFromBytes) {
     size_t result = Utils::getNumberFromBytes(buffer, count);
 
     EXPECT_EQ(result, value);
+}
+
+static std::string sha256Hex(const std::string& s) {
+    uint8_t digest[32];
+    Sha256::hash(s.data(), s.size(), digest);
+    return Sha256::hex(digest);
+}
+
+TEST(Sha256, KnownVectors) {
+    EXPECT_EQ(sha256Hex(""),
+              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    EXPECT_EQ(sha256Hex("abc"),
+              "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    EXPECT_EQ(sha256Hex("The quick brown fox jumps over the lazy dog"),
+              "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592");
+}
+
+TEST(Sha256, CrossesBlockBoundary) {
+    // 1 000 000 'a' -> a well-known SHA-256 test vector; exercises multiple
+    // 64-byte blocks and the length padding.
+    std::string million(1000000, 'a');
+    EXPECT_EQ(sha256Hex(million),
+              "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
+}
+
+TEST(Sha256, DetectsSingleBitFlip) {
+    std::string a(256, 'x');
+    std::string b = a;
+    b[100] ^= 0x01;
+    EXPECT_NE(sha256Hex(a), sha256Hex(b));
 }
 
 int main(int argc, char** argv) {

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -89,7 +89,14 @@ run_test() {
         return 1
     fi
 
-    echo "PASS: [$label] $size_kb KiB transferred and matches source"
+    # The receiver must have verified the SHA-256 the sender announced.
+    if ! grep -q "sha256 verified" "$recv_log"; then
+        echo "FAIL: [$label] receiver did not verify the file checksum"
+        tail -20 "$recv_log"
+        return 1
+    fi
+
+    echo "PASS: [$label] $size_kb KiB transferred, checksum verified"
 }
 
 # Args: label, size_kb, recv_bind_port, send_bind_port, recv_ttl, send_ttl


### PR DESCRIPTION
Расширяет проволочный протокол (через новое поле версии в NEW_PACKET), закрывая несколько medium-багов из аудита и добавляя фичи для реального использования.

## Что нового

- **Целостность SHA-256.** Хеш всего файла едет в NEW_PACKET; receiver пересчитывает его после сборки и **отказывается писать файл при несовпадении** (exit 2) — тихая порча превращается в чистый отказ. Самодостаточная реализация `src/Sha256.hpp` (проверена на FIPS-векторах).
- **Имя файла в протоколе.** `filecast receive` теперь работает **без аргумента** — сохраняет под именем от отправителя (явный путь по-прежнему в приоритете). `sanitizeName()` режет каталоги и отвергает traversal, `:` (drive-relative / ADS) и зарезервированные имена устройств.
- **Согласование chunk_size.** Размер чанка (MTU отправителя) передаётся в NEW_PACKET; receiver нарезает по нему и растит приёмный буфер — **разный `--mtu` у сторон больше не приводит к livelock**, а корректно передаёт файл.

## Рефакторинг и качество

- `Sender::run`/`Receiver::run` разбиты на функции (устранены 5 дублей cleanup-кода и дублированный парсинг TRANSFER); все функции CCN < 15.
- Добавлены unit-тесты SHA-256 (включая границы блоков), e2e проверяет факт верификации контрольной суммы.

## Проверка

- Полный `ctest` зелёный (unit + e2e + e2e_lossy); сборка `-Wall -Wextra` чистая; lizard 0 warnings.
- Ручные проверки: базовая передача с verify, `receive` без имени, MTU-mismatch (1400/1500) доходит, детекция порчи (rc=2, файл не пишется).
- **Адверсариальное ревью (5 ревьюеров + скептики)** нашло и исправлено до мержа: DoS через `chunk_size=1` (OOM двумя пакетами) → ограничение 64..65507; Windows-обход `sanitizeName` (`C:evil`/ADS/устройства) → отклонение. Обе инъекции перепроверены — receiver отвергает без краха.

## Известно / follow-up
- Отправитель диктует имя файла → перезапись файла в cwd без спроса (как `curl -O`; path traversal заблокирован). Ревью оценило как low/hardening — предлагаю отдельно: писать в `.part` + `--overwrite`.

> ⚠️ Несовместимо с v1 по проволочному формату — обе стороны должны быть одной версии. При релизе поднять версию.