### PR TITLE
UX: progress bar, --rate limit, safe output writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ LAN at once, with automatic retransmission of dropped packets.
 - End-to-end SHA-256 integrity check — a corrupted file is rejected, not saved
 - File name travels with the transfer, so `receive` needs no arguments
 - Chunk size negotiated in-band, so mismatched `--mtu` no longer stalls
-- Configurable MTU and timeout
+- Live progress bar with speed and ETA, and a rate limit in Mbit/s
+- Never clobbers an existing file unless you pass `--overwrite`
 - Windows, Linux, and macOS binaries built on every release
 
 ## Quick Start
@@ -91,7 +92,10 @@ filecast receive [file] [options]    # receive a file (default: name from sender
 | `--bind-port` | `33333`    | 1..65535 | Local port to bind on |
 | `--mtu`       | `1500`     | 64..65507 | Max packet size in bytes |
 | `--ttl`       | `15`       | > 0 | Seconds of silence before giving up |
-| `--delay-ms`  | `20`       | ≥ 0 | Pause between successive packets (use `0` for loopback / tests) |
+| `--rate`      | `100`      | > 0 | Target send rate in Mbit/s |
+| `--overwrite` | off        | — | Overwrite an existing output file |
+| `-v, --verbose` | off      | — | Log every packet instead of a progress bar |
+| `--delay-ms`  | —          | ≥ 0 | Advanced: fixed inter-packet pause in ms; overrides `--rate` (`0` blasts at full speed, used by tests) |
 | `-h, --help`  | —          | — | Print help |
 | `--version`   | —          | — | Print version |
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -2,11 +2,13 @@
 
 std::string fileName;
 bool        fileNameFromCli = false;
+bool        verbose         = false;
+bool        overwrite       = false;
 
-int mtu      = 0;
-int ttl      = 0;
-int ttl_max  = 0;
-int delay_ms = 0;
+int     mtu     = 0;
+int     ttl     = 0;
+int     ttl_max = 0;
+int64_t pace_us = 0;
 
 SOCKET _socket;
 

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -3,18 +3,21 @@
 
 #include "Utils.hpp"
 
+#include <cstdint>
 #include <string>
 
 
 extern std::string fileName;     // File Name to transfer or receive
 extern bool        fileNameFromCli; // true if the user gave an explicit output name
+extern bool        verbose;      // per-packet logging instead of a progress bar
+extern bool        overwrite;    // allow overwriting an existing output file
 
 extern int mtu;     // Max packet size to send and receive
 
 extern int ttl;     // Current wait time for new packages before shutting down
 extern int ttl_max; // Maximum wait time for new packages before shutting down
 
-extern int delay_ms; // Inter-packet pause when blasting parts / RESENDs
+extern int64_t pace_us; // Inter-packet pause in microseconds (from --rate/--delay-ms)
 
 extern SOCKET _socket;
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -33,11 +33,14 @@ struct CliOptions {
     int         ttl       = 15;
     int         port      = 33333;
     int         bind_port = 33333;
-    int         delay_ms  = 20;
+    int         rate      = 100;        // target send rate, Mbit/s
+    int64_t     pace_us   = 0;          // inter-packet pause derived from rate/delay
     std::string file;
     bool        file_from_cli = false;  // true if the user named the file
-    bool        use_broadcast = true;  // false when --to <ip> is given
-    std::string target;                // destination IP for unicast
+    bool        use_broadcast = true;   // false when --to <ip> is given
+    std::string target;                 // destination IP for unicast
+    bool        verbose   = false;      // per-packet logging instead of a bar
+    bool        overwrite = false;      // allow overwriting an existing file
 };
 
 void buildOptions(cxxopts::Options& options) {
@@ -53,7 +56,10 @@ void buildOptions(cxxopts::Options& options) {
         ("bind-port", "Local UDP port to bind on",            cxxopts::value<int>()->default_value("33333"))
         ("mtu",       "Max packet size in bytes",             cxxopts::value<int>()->default_value("1500"))
         ("ttl",       "Seconds of silence before giving up",  cxxopts::value<int>()->default_value("15"))
-        ("delay-ms",  "Delay between successive packets, ms", cxxopts::value<int>()->default_value("20"))
+        ("rate",      "Target send rate, Mbit/s",             cxxopts::value<int>()->default_value("100"))
+        ("delay-ms",  "Override inter-packet pause, ms (advanced, overrides --rate)", cxxopts::value<int>())
+        ("v,verbose", "Log every packet instead of a progress bar")
+        ("overwrite", "Overwrite an existing output file")
         ("h,help",    "Print help")
         ("version",   "Print version");
 
@@ -64,11 +70,11 @@ void printUsage(cxxopts::Options& options, std::ostream& os) {
     os << options.help();
     os << "\nCommands:\n"
        << "  send <file>       Broadcast <file> to every host on the LAN\n"
-       << "  receive [file]    Receive a file (saved as [file], default file.out)\n"
+       << "  receive [file]    Receive a file (saved under the sender's name by default)\n"
        << "\nExamples:\n"
        << "  filecast send photo.jpg\n"
        << "  filecast receive\n"
-       << "  filecast send photo.jpg --to 192.168.1.50\n";
+       << "  filecast send photo.jpg --to 192.168.1.50 --rate 500\n";
 }
 
 // Peel the subcommand off argv[1], handling global --help/--version. Sets
@@ -118,8 +124,8 @@ bool validateNumericFlags(const CliOptions& opt) {
         std::cerr << "Error: --bind-port must be between 1 and 65535" << std::endl;
         return false;
     }
-    if (opt.delay_ms < 0) {
-        std::cerr << "Error: --delay-ms must be 0 or greater" << std::endl;
+    if (opt.rate <= 0) {
+        std::cerr << "Error: --rate must be greater than 0" << std::endl;
         return false;
     }
     return true;
@@ -132,9 +138,25 @@ bool collectOptions(const cxxopts::ParseResult& result, bool is_sender, CliOptio
     opt.ttl       = result["ttl"].as<int>();
     opt.port      = result["port"].as<int>();
     opt.bind_port = result["bind-port"].as<int>();
-    opt.delay_ms  = result["delay-ms"].as<int>();
+    opt.rate      = result["rate"].as<int>();
 
     if (!validateNumericFlags(opt)) return false;
+
+    // Pace packets by --rate (Mbit/s); an explicit --delay-ms overrides it (used
+    // by the loopback tests with 0 to blast at full speed).
+    if (result.count("delay-ms")) {
+        int delay_ms = result["delay-ms"].as<int>();
+        if (delay_ms < 0) {
+            std::cerr << "Error: --delay-ms must be 0 or greater" << std::endl;
+            return false;
+        }
+        opt.pace_us = static_cast<int64_t>(delay_ms) * 1000;
+    } else {
+        opt.pace_us = static_cast<int64_t>(opt.mtu) * 8 / opt.rate;
+    }
+
+    opt.verbose   = (result.count("verbose") != 0);
+    opt.overwrite = (result.count("overwrite") != 0);
 
     // send needs an explicit file; receive may take the name from the sender.
     const bool has_file = (result.count("file") != 0);
@@ -159,7 +181,7 @@ int setupSocket(const CliOptions& opt) {
         CLEANUP_NETWORK();
         return 1;
     }
-    std::cout << "Ok: Socket created" << std::endl;
+    if (verbose) std::cout << "Ok: Socket created" << std::endl;
 
     int reuseAddr = 1;
     if (setsockopt(_socket, SOL_SOCKET, SO_REUSEADDR,
@@ -191,7 +213,7 @@ int setupSocket(const CliOptions& opt) {
             std::cerr << "Error: Can't get access to broadcast" << std::endl;
             cleanupAndExit(1);
         }
-        std::cout << "Ok: Got access to broadcast" << std::endl;
+        if (verbose) std::cout << "Ok: Got access to broadcast" << std::endl;
         broadcast_address.sin_addr.s_addr = INADDR_BROADCAST;
     } else {
         if (inet_pton(AF_INET, opt.target.c_str(), &broadcast_address.sin_addr) != 1) {
@@ -204,7 +226,7 @@ int setupSocket(const CliOptions& opt) {
         std::cerr << "Error: Can't bind socket" << std::endl;
         cleanupAndExit(1);
     }
-    std::cout << "Ok: Socket bound" << std::endl;
+    if (verbose) std::cout << "Ok: Socket bound" << std::endl;
 
     #if defined(_WIN32) || defined(_WIN64)
     DWORD tv = 1000;  // user timeout in milliseconds [ms]
@@ -273,9 +295,11 @@ int main(int argc, char* argv[]) {
     mtu             = opt.mtu;
     ttl             = opt.ttl;
     ttl_max         = opt.ttl;
-    delay_ms        = opt.delay_ms;
+    pace_us         = opt.pace_us;
     fileName        = opt.file;
     fileNameFromCli = opt.file_from_cli;
+    verbose         = opt.verbose;
+    overwrite       = opt.overwrite;
 
     int rc = setupSocket(opt);
     if (rc != 0) {

--- a/src/Progress.hpp
+++ b/src/Progress.hpp
@@ -1,0 +1,109 @@
+#ifndef FILECAST_PROGRESS_H
+#define FILECAST_PROGRESS_H
+
+// Human-readable formatting and a throttled single-line progress bar. The bar is
+// drawn on stderr with a carriage return so stdout stays clean for piping; in
+// verbose mode it is silent and the caller logs per packet instead.
+
+#include <cstdint>
+#include <cstdio>
+#include <chrono>
+#include <string>
+
+namespace Progress {
+
+// e.g. 1610612736 -> "1.5 GiB"
+inline std::string humanBytes(uint64_t n) {
+    const char* units[] = {"B", "KiB", "MiB", "GiB", "TiB"};
+    double value = static_cast<double>(n);
+    int unit = 0;
+    while (value >= 1024.0 && unit < 4) {
+        value /= 1024.0;
+        ++unit;
+    }
+    char buf[32];
+    snprintf(buf, sizeof(buf), unit == 0 ? "%.0f %s" : "%.1f %s", value, units[unit]);
+    return buf;
+}
+
+// bytes/second -> "12.3 MiB/s"
+inline std::string humanRate(double bytes_per_sec) {
+    if (bytes_per_sec < 0) bytes_per_sec = 0;
+    return humanBytes(static_cast<uint64_t>(bytes_per_sec)) + "/s";
+}
+
+// seconds -> "3.2s", "1m03s" or ">99h" (clamped so a huge ETA can't overflow int)
+inline std::string humanDuration(double sec) {
+    char buf[32];
+    if (sec < 0) sec = 0;
+    if (sec < 60.0) {
+        snprintf(buf, sizeof(buf), "%.1fs", sec);
+    } else if (sec >= 360000.0) {  // >= 100 hours: report a bound, don't cast
+        snprintf(buf, sizeof(buf), ">99h");
+    } else {
+        int total = static_cast<int>(sec + 0.5);
+        snprintf(buf, sizeof(buf), "%dm%02ds", total / 60, total % 60);
+    }
+    return buf;
+}
+
+class Reporter {
+public:
+    Reporter() = default;
+
+    void start(const std::string& label, uint64_t total, bool verbose) {
+        verbose_ = verbose;
+        label_   = label;
+        total_   = total;
+        start_   = std::chrono::steady_clock::now();
+        last_    = start_;
+        active_  = true;
+    }
+
+    // Redraw the bar for `done` bytes, at most ~10x/second. No-op in verbose mode.
+    void update(uint64_t done) {
+        if (verbose_ || !active_) return;
+        auto now = std::chrono::steady_clock::now();
+        if (done < total_ &&
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - last_).count() < 100) {
+            return;
+        }
+        last_ = now;
+
+        double secs = std::chrono::duration<double>(now - start_).count();
+        double rate = secs > 0 ? done / secs : 0;
+        int pct = total_ ? static_cast<int>(done * 100 / total_) : 0;
+        std::string eta = (rate > 0 && done < total_)
+            ? humanDuration((total_ - done) / rate)
+            : "--";
+
+        fprintf(stderr, "\r\033[K%s: %d%% %s/%s  %s  ETA %s",
+                label_.c_str(), pct, humanBytes(done).c_str(), humanBytes(total_).c_str(),
+                humanRate(rate).c_str(), eta.c_str());
+        fflush(stderr);
+    }
+
+    // Clear the bar. Does not print a summary — the caller prints its own on stdout.
+    void finish() {
+        if (verbose_ || !active_) return;
+        fprintf(stderr, "\r\033[K");
+        fflush(stderr);
+        active_ = false;
+    }
+
+    double elapsed() const {
+        return std::chrono::duration<double>(std::chrono::steady_clock::now() - start_).count();
+    }
+
+private:
+    bool verbose_ = false;
+    std::string label_;
+    uint64_t total_ = 0;
+    std::chrono::steady_clock::time_point start_;
+    std::chrono::steady_clock::time_point last_;
+    bool active_ = false;
+};
+
+}  // namespace Progress
+
+#endif  // FILECAST_PROGRESS_H

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -1,6 +1,7 @@
 #include "Utils.hpp"
 #include "Config.hpp"
 #include "Sha256.hpp"
+#include "Progress.hpp"
 
 #include <iostream>
 #include <fstream>
@@ -50,6 +51,11 @@ uint8_t expected_hash[32] = {0};
 
 // File name announced by the sender, used when the user did not name the output.
 std::string announced_name;
+
+// Progress bar for the current transfer and the running total of stored payload
+// bytes that drives it.
+Progress::Reporter reporter;
+size_t received_bytes = 0;
 
 /**
  * List of received parts
@@ -123,13 +129,22 @@ bool handleTransfer(const char* buf, int64_t length) {
 
     parts.insert(part);
     memcpy(file + part * chunk_size, buf + TRANSFER_HEADER, size);
-    std::cout << "Receive " << part << " part with size " << size << std::endl;
+    received_bytes += size;
+    reporter.update(received_bytes);
+    if (verbose) std::cout << "Receive " << part << " part with size " << size << std::endl;
     return true;
+}
+
+bool fileExists(const std::string& path) {
+    std::ifstream f(path);
+    return f.good();
 }
 
 // Verify the reassembled file against the announced digest and write it out.
 // Returns a process exit code.
 int verifyAndWrite() {
+    reporter.finish();
+
     uint8_t got[32];
     Sha256::hash(file, file_length, got);
     if (memcmp(got, expected_hash, 32) != 0) {
@@ -138,24 +153,59 @@ int verifyAndWrite() {
         file = nullptr;
         return 2;
     }
-    std::cout << "Ok: sha256 verified " << Sha256::hex(got) << std::endl;
 
-    std::ofstream output(fileName, std::ofstream::binary);
+    // Refuse to clobber an existing file unless the user opted in.
+    if (!overwrite && fileExists(fileName)) {
+        std::cerr << "Error: output file " << fileName
+                  << " already exists (use --overwrite to replace it)" << std::endl;
+        delete[] file;
+        file = nullptr;
+        return 2;
+    }
+
+    // Write to a temporary and rename on success, so an interrupted write never
+    // leaves a truncated file under the target name.
+    const std::string tmp = fileName + ".part";
+    std::ofstream output(tmp, std::ofstream::binary | std::ofstream::trunc);
     if (!output.is_open()) {
-        std::cerr << "Error: Can't open output file " << fileName << std::endl;
+        std::cerr << "Error: Can't open output file " << tmp << std::endl;
         delete[] file;
         file = nullptr;
         return 2;
     }
     output.write(file, static_cast<std::streamsize>(file_length));
+    output.close();
     if (!output) {
-        std::cerr << "Error: Failed to write output file " << fileName << std::endl;
+        std::cerr << "Error: Failed to write output file " << tmp << std::endl;
+        std::remove(tmp.c_str());
         delete[] file;
         file = nullptr;
         return 2;
     }
-    output.close();
-    std::cout << "File successfully received as " << fileName << std::endl;
+    // On POSIX rename() atomically replaces the target, so no pre-remove is
+    // needed. On Windows rename() refuses to overwrite, so drop the target
+    // first (only meaningful with --overwrite, since otherwise it does not exist).
+    #if defined(_WIN32) || defined(_WIN64)
+    std::remove(fileName.c_str());
+    #endif
+    if (std::rename(tmp.c_str(), fileName.c_str()) != 0) {
+        // Keep the verified .part so the transfer is not lost — the RAM copy is
+        // freed below, so this file is the only remaining copy of the data.
+        std::cerr << "Error: Failed to finalize " << fileName
+                  << "; verified data kept at " << tmp << std::endl;
+        delete[] file;
+        file = nullptr;
+        return 2;
+    }
+
+    double secs = reporter.elapsed();
+    double rate = secs > 0 ? file_length / secs : 0;
+    std::cout << "Received " << fileName << " (" << Progress::humanBytes(file_length) << ")";
+    if (secs > 0) {
+        std::cout << " in " << Progress::humanDuration(secs)
+                  << " at " << Progress::humanRate(rate);
+    }
+    std::cout << "; sha256 verified" << std::endl;
 
     delete[] file;
     file = nullptr;
@@ -186,8 +236,8 @@ int checkParts() {
             Utils::writeBytesFromNumber(buffer + 10, index,      4);
             sendto(_socket, buffer, 14, 0, reinterpret_cast<sockaddr*>(&broadcast_address),
                    sizeof(broadcast_address));
-            std::cout << "Request part of file with index " << index << std::endl;
-            if (delay_ms > 0) std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+            if (verbose) std::cout << "Request part of file with index " << index << std::endl;
+            if (pace_us > 0) std::this_thread::sleep_for(std::chrono::microseconds(pace_us));
         }
 
         // Drain every packet already queued (until the socket times out via
@@ -221,6 +271,7 @@ int checkParts() {
     delete[] buffer;
 
     if (!emptyParts.empty()) {
+        reporter.finish();  // clear the bar before the error line
         std::cerr << "Error: Transfer timed out, file is incomplete" << std::endl;
         delete[] file;
         file = nullptr;
@@ -250,6 +301,33 @@ bool announceValid(size_t announced, size_t chunk, int& exit_code) {
     if (chunk < 64 || chunk > 65507) {
         std::cerr << "Error: Sender announced invalid chunk size " << chunk << std::endl;
         exit_code = 2;
+        return false;
+    }
+    return true;
+}
+
+// Grow the receive buffer to hold a full chunk and (re)allocate the file buffer
+// for a new transfer. Sets exit_code and returns false on allocation failure.
+bool allocateBuffers(char*& buf, size_t& bufcap, int& exit_code) {
+    size_t need = chunk_size + TRANSFER_HEADER;
+    if (need > bufcap) {
+        delete[] buf;
+        bufcap = need;
+        buf = new (std::nothrow) char[bufcap];
+        if (!buf) {
+            std::cerr << "Error: Can't allocate receive buffer" << std::endl;
+            exit_code = 1;
+            return false;
+        }
+    }
+
+    delete[] file;
+    parts.clear();
+    received_bytes = 0;
+    file = new (std::nothrow) char[file_length];
+    if (!file) {
+        std::cerr << "Error: Can't allocate " << file_length << " bytes" << std::endl;
+        exit_code = 1;
         return false;
     }
     return true;
@@ -297,31 +375,14 @@ bool handleNewPacket(char*& buf, size_t& bufcap, int64_t length, int& exit_code)
     announced_name = sanitizeName(std::string(buf + NEW_PACKET_FIXED, name_len));
     if (!fileNameFromCli) fileName = announced_name;
 
-    // Grow the receive buffer if a TRANSFER for this chunk size would not fit.
-    size_t need = chunk_size + TRANSFER_HEADER;
-    if (need > bufcap) {
-        delete[] buf;
-        bufcap = need;
-        buf = new (std::nothrow) char[bufcap];
-        if (!buf) {
-            std::cerr << "Error: Can't allocate receive buffer" << std::endl;
-            exit_code = 1;
-            return false;
-        }
-    }
+    if (!allocateBuffers(buf, bufcap, exit_code)) return false;
 
-    delete[] file;
-    parts.clear();
-    file = new (std::nothrow) char[file_length];
-    if (!file) {
-        std::cerr << "Error: Can't allocate " << file_length << " bytes" << std::endl;
-        exit_code = 1;
-        return false;
+    if (verbose) {
+        std::cout << "Receive information about new file: " << fileName
+                  << " (" << file_length << " bytes)" << std::endl;
+        std::cout << "Number of parts: " << totalParts() << std::endl;
     }
-
-    std::cout << "Receive information about new file: " << fileName
-              << " (" << file_length << " bytes)" << std::endl;
-    std::cout << "Number of parts: " << totalParts() << std::endl;
+    reporter.start("Receiving " + fileName, file_length, verbose);
     return true;
 }
 
@@ -332,7 +393,7 @@ void handleFinish(const char* buf, int64_t length, bool& finish) {
     if (Utils::getNumberFromBytes(buf + 6, 4) != session_id) return;
     ttl = ttl_max;
     if (!finish) {
-        std::cout << "Server finished transferring" << std::endl;
+        if (verbose) std::cout << "Server finished transferring" << std::endl;
         finish = true;
     }
 }
@@ -346,6 +407,10 @@ int run() {
     if (!buffer) {
         std::cerr << "Error: Can't allocate receive buffer" << std::endl;
         return 1;
+    }
+
+    if (!verbose) {
+        std::cerr << "Waiting for a sender... (Ctrl+C to cancel)" << std::endl;
     }
 
     while (ttl > 0) {
@@ -392,6 +457,7 @@ int run() {
         }
     }
     // ttl exhausted before FINISH: the transfer did not complete.
+    reporter.finish();  // clear the bar if one was drawn
     delete[] buffer;
     delete[] file;
     file = nullptr;

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -1,6 +1,7 @@
 #include "Utils.hpp"
 #include "Config.hpp"
 #include "Sha256.hpp"
+#include "Progress.hpp"
 
 #include <iostream>
 #include <fstream>
@@ -10,6 +11,7 @@
 #include <cstdio>
 #include <cstdint>
 #include <string>
+#include <algorithm>
 #include <map>
 #include <random>
 
@@ -71,7 +73,14 @@ void sendPart(size_t part_index) {
         std::cerr << "Warning: Failed to send part " << part_index << std::endl;
         return;
     }
-    std::cout << "Part " << part_index << " with size " << packet_length << " was sent" << std::endl;
+    if (verbose) {
+        std::cout << "Part " << part_index << " with size " << packet_length << " was sent" << std::endl;
+    }
+}
+
+// Pause between packets to pace the transfer (0 = blast at full speed).
+void pace() {
+    if (pace_us > 0) std::this_thread::sleep_for(std::chrono::microseconds(pace_us));
 }
 
 void sendFinish() {
@@ -137,7 +146,7 @@ void sendNewPacket() {
     // Digest of the whole file; the receiver verifies against it after reassembly.
     uint8_t file_hash[32];
     Sha256::hash(file, file_length, file_hash);
-    std::cout << "Ok: sha256 " << Sha256::hex(file_hash) << std::endl;
+    if (verbose) std::cout << "Ok: sha256 " << Sha256::hex(file_hash) << std::endl;
 
     // Name the receiver saves under unless it was given an explicit output path.
     // Clamp so the whole NEW_PACKET fits the send buffer (2 * mtu) and the length
@@ -163,16 +172,18 @@ void sendNewPacket() {
                    sizeof(broadcast_address)) < 0) {
             std::cerr << "Warning: Failed to send NEW_PACKET" << std::endl;
         }
-        if (i + 1 < 3 && delay_ms > 0) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
-        }
+        if (i + 1 < 3) pace();
     }
-    std::cout << "Ok: Sent information about new file with size " << file_length << std::endl;
+    if (verbose) {
+        std::cout << "Ok: Sent information about new file with size " << file_length << std::endl;
+    }
 }
 
 // Serve RESEND requests until ttl expires, re-announcing FINISH periodically.
-void serveResends(size_t total_parts) {
+// Returns how many parts were re-sent on request.
+size_t serveResends(size_t total_parts) {
     int64_t lastFinishSendTime = 0;
+    size_t  resent = 0;
 
     SOCKADDR_IN sender_address;
     memset(&sender_address, 0, sizeof(sender_address));
@@ -209,8 +220,11 @@ void serveResends(size_t total_parts) {
 
         if (duration - sent_part[part] >= 1) {
             sent_part[part] = duration;
-            std::cout << "Client requested part of file with index " << part << std::endl;
+            if (verbose) {
+                std::cout << "Client requested part of file with index " << part << std::endl;
+            }
             sendPart(part);
+            ++resent;
         }
         // Re-announce completion at most once a second.
         if (duration - lastFinishSendTime >= 1) {
@@ -218,6 +232,7 @@ void serveResends(size_t total_parts) {
             sendFinish();
         }
     }
+    return resent;
 }
 
 // Returns a process exit code: 0 on success, non-zero on failure.
@@ -231,22 +246,36 @@ int run() {
         CLEANUP_NETWORK();
         return 1;
     }
-    std::cout << "Ok: File successfully copied to RAM" << std::endl;
+    if (verbose) std::cout << "Ok: File successfully copied to RAM" << std::endl;
 
     sendNewPacket();
+
+    const std::string name = baseName(fileName);
+    Progress::Reporter reporter;
+    reporter.start("Sending " + name, file_length, verbose);
 
     size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
     for (size_t part_index = 0; part_index < total_parts; ++part_index) {
         sent_part.insert({ part_index, 0 });
         sendPart(part_index);
-        if (delay_ms > 0) std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+        reporter.update(std::min((part_index + 1) * static_cast<size_t>(mtu), file_length));
+        pace();
     }
+    reporter.finish();
+
+    double secs = reporter.elapsed();
+    double rate = secs > 0 ? file_length / secs : 0;
+    std::cout << "Sent " << name << " (" << Progress::humanBytes(file_length)
+              << ") in " << Progress::humanDuration(secs)
+              << " at " << Progress::humanRate(rate) << std::endl;
 
     sendFinish();
-    std::cout << "Ok: File transfer complete" << std::endl;
 
-    serveResends(total_parts);
-    std::cout << "Ok: Transfer session ended" << std::endl;
+    size_t resent = serveResends(total_parts);
+    if (resent > 0) {
+        std::cout << "Re-sent " << resent << " part(s) on request" << std::endl;
+    }
+    if (verbose) std::cout << "Ok: Transfer session ended" << std::endl;
 
     delete[] buffer;
     delete[] file;

--- a/tests/e2e_lossy.sh
+++ b/tests/e2e_lossy.sh
@@ -72,7 +72,7 @@ run_test() {
     sleep 0.5
 
     echo "==> [$label] starting receiver (bind=$RECV_BIND, target=$PROXY_BACK_IN)"
-    "$BINARY" receive "$dst" --to 127.0.0.1 \
+    "$BINARY" receive "$dst" --to 127.0.0.1 --verbose \
               --bind-port "$RECV_BIND" --port "$PROXY_BACK_IN" \
               --ttl 15 --delay-ms 0 \
         > "$recv_log" 2>&1 &


### PR DESCRIPTION
Пункт 1 дорожной карты — UX-рывок. Заменяет лог на каждый пакет на интерфейс, пригодный для реального использования.

## Что нового

- **Прогресс-бар** — одна перерисовываемая строка (процент, human-readable размеры, скорость, ETA) на stderr, чтобы stdout оставался пайпабельным. Обе стороны печатают итог: `Sent/Received <name> (<size>) in <t> at <rate>`.
- **`--rate <Мбит/с>`** (дефолт 100) — пейсинг в микросекундах вместо старого `--delay-ms 20`, который ограничивал передачу ~73 КиБ/с. **Файл 5 МиБ теперь идёт ~1с вместо ~66с.** `--delay-ms` остался как advanced-override.
- **`--verbose`** — старый детальный per-packet лог; служебные `Ok: ...` теперь тоже под ним.
- **Безопасная запись** — receiver пишет в `<name>.part` и переименовывает по успеху (обрыв не оставляет битый файл под целевым именем), и **отказывается перезаписывать существующий файл без `--overwrite`**. При сбое rename верифицированный `.part` сохраняется.

## Проверка

- Полный `ctest` зелёный; сборка `-Wall -Wextra` чистая; lizard 0 warnings (CCN<15); cppcheck/cpplint чисто.
- Ручные проверки: прогресс/скорость/ETA/итог, 5 МиБ за 1с, `--overwrite` (отказ без флага, перезапись с флагом), `.part` не остаётся, `receive` без имени, sha совпадает; очистка бара на таймауте.
- **Адверсариальное ревью (4 ревьюера + скептики)** нашло 7 low-находок; исправлены реальные: rename-атомарность на POSIX + сохранение `.part` при сбое, очистка бара на путях ошибок, UB-clamp в форматтере ETA, `Ok: sha256` под verbose.

## Известно / follow-up (low, отложено)
Имя `.part` предсказуемо и `std::ofstream` следует за симлинком (нет `O_EXCL`/`O_NOFOLLOW`); TOCTOU-окно в no-clobber проверке. Требует platform-specific `open()`; все low и предполагают локальный доступ к рабочему каталогу receiver (вне модели угроз LAN-broadcast). Кандидат на отдельный проход при желании усилить.