### PR TITLE
Hardening: ASan/UBSan CI, testable protocol helpers, safe file writing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,3 +62,32 @@ jobs:
           else
             ctest --test-dir build --output-on-failure
           fi
+
+  # Build with AddressSanitizer + UndefinedBehaviorSanitizer and run the whole
+  # suite, so memory errors and UB in the manual buffer handling are caught in CI.
+  sanitizers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtest-dev cmake
+
+      - name: Configure (ASan + UBSan)
+        run: |
+          cmake -S . -B build-asan \
+                -DCMAKE_BUILD_TYPE=Debug \
+                -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g"
+
+      - name: Build
+        run: cmake --build build-asan
+
+      - name: Run tests
+        env:
+          ASAN_OPTIONS: detect_leaks=1:abort_on_error=1
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: ctest --test-dir build-asan --output-on-failure

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -1,0 +1,68 @@
+#ifndef FILECAST_PROTOCOL_H
+#define FILECAST_PROTOCOL_H
+
+// Pure, socket-free protocol helpers shared by the receiver and the unit tests.
+// Keeping the framing/validation logic here (rather than inline in Receiver.cpp)
+// makes it testable without spinning up sockets.
+
+#include <cstddef>
+#include <cctype>
+#include <algorithm>
+#include <string>
+
+namespace Protocol {
+
+// Valid chunk size range (the sender's --mtu bounds). The lower bound also caps
+// the part count, so a forged tiny chunk cannot blow up the receiver.
+constexpr size_t MIN_CHUNK = 64;
+constexpr size_t MAX_CHUNK = 65507;
+
+inline size_t totalParts(size_t file_length, size_t chunk_size) {
+    if (chunk_size == 0) return 0;  // guard the reusable helper against misuse
+    return (file_length + chunk_size - 1) / chunk_size;
+}
+
+// Expected payload size of `part`: the full chunk for every part but the last,
+// and the remaining bytes for the last part.
+inline size_t expectedPartSize(size_t part, size_t file_length, size_t chunk_size) {
+    size_t total = totalParts(file_length, chunk_size);
+    return (part + 1 < total) ? chunk_size : (file_length - part * chunk_size);
+}
+
+// Are the announced file/chunk sizes acceptable? file in (0, maxFile],
+// chunk in [MIN_CHUNK, MAX_CHUNK].
+inline bool announceInRange(size_t announced, size_t chunk, size_t maxFile) {
+    if (announced == 0 || announced > maxFile) return false;
+    if (chunk < MIN_CHUNK || chunk > MAX_CHUNK) return false;
+    return true;
+}
+
+// A Windows reserved device name (CON, NUL, COM1..9, LPT1..9), optionally with
+// an extension — opening it writes to a device, not a file.
+inline bool isReservedDeviceName(const std::string& name) {
+    std::string stem = name.substr(0, name.find('.'));
+    std::transform(stem.begin(), stem.end(), stem.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    if (stem == "CON" || stem == "PRN" || stem == "AUX" || stem == "NUL") return true;
+    if (stem.size() == 4 && (stem.compare(0, 3, "COM") == 0 || stem.compare(0, 3, "LPT") == 0) &&
+        stem[3] >= '1' && stem[3] <= '9') {
+        return true;
+    }
+    return false;
+}
+
+// Reduce a sender-supplied name to a safe base name in the working directory:
+// strip directories, and reject traversal, ':' (Windows drive-relative / ADS)
+// and reserved device names by falling back to "file.out".
+inline std::string sanitizeName(const std::string& raw) {
+    size_t slash = raw.find_last_of("/\\");
+    std::string name = (slash == std::string::npos) ? raw : raw.substr(slash + 1);
+    if (name.empty() || name == "." || name == "..") return "file.out";
+    if (name.find(':') != std::string::npos) return "file.out";
+    if (isReservedDeviceName(name)) return "file.out";
+    return name;
+}
+
+}  // namespace Protocol
+
+#endif  // FILECAST_PROTOCOL_H

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -2,6 +2,7 @@
 #include "Config.hpp"
 #include "Sha256.hpp"
 #include "Progress.hpp"
+#include "Protocol.hpp"
 
 #include <iostream>
 #include <fstream>
@@ -11,10 +12,16 @@
 #include <cstdio>
 #include <cstdint>
 #include <cctype>
+#include <cerrno>
 #include <string>
 #include <algorithm>
+#include <random>
 #include <vector>
 #include <set>
+
+#if !defined(_WIN32) && !defined(_WIN64)
+#include <fcntl.h>   // open, O_EXCL, O_NOFOLLOW
+#endif
 
 using namespace std::chrono_literals;
 
@@ -63,7 +70,7 @@ size_t received_bytes = 0;
 std::set<size_t> parts;
 
 size_t totalParts() {
-    return (file_length + chunk_size - 1) / chunk_size;
+    return Protocol::totalParts(file_length, chunk_size);
 }
 
 /**
@@ -76,33 +83,6 @@ std::vector<size_t> getEmptyParts() {
         if (parts.find(i) == parts.end()) result.push_back(i);
     }
     return result;
-}
-
-// A Windows reserved device name (CON, NUL, COM1..9, LPT1..9, ...), optionally
-// with an extension. Opening such a name writes to a device, not a file.
-bool isReservedDeviceName(const std::string& name) {
-    std::string stem = name.substr(0, name.find('.'));
-    std::transform(stem.begin(), stem.end(), stem.begin(),
-                   [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
-    if (stem == "CON" || stem == "PRN" || stem == "AUX" || stem == "NUL") return true;
-    if (stem.size() == 4 && (stem.compare(0, 3, "COM") == 0 || stem.compare(0, 3, "LPT") == 0) &&
-        stem[3] >= '1' && stem[3] <= '9') {
-        return true;
-    }
-    return false;
-}
-
-// Keep only the base name of a sender-supplied path and refuse anything that
-// could escape the working directory, so a hostile sender cannot make us write
-// elsewhere. Besides '/' and '\\', a ':' on Windows introduces a drive-relative
-// path or an alternate data stream, and reserved names map to devices.
-std::string sanitizeName(const std::string& raw) {
-    size_t slash = raw.find_last_of("/\\");
-    std::string name = (slash == std::string::npos) ? raw : raw.substr(slash + 1);
-    if (name.empty() || name == "." || name == "..") return "file.out";
-    if (name.find(':') != std::string::npos) return "file.out";
-    if (isReservedDeviceName(name)) return "file.out";
-    return name;
 }
 
 // Validate and store one TRANSFER packet. Returns true when a new part was
@@ -121,10 +101,7 @@ bool handleTransfer(const char* buf, int64_t length) {
     // For non-final parts size must equal the chunk size; for the final part it
     // must equal the remaining bytes. Anything else is malformed and would
     // either silently zero-pad data or write past the file buffer.
-    size_t expected = (part + 1 < total)
-        ? chunk_size
-        : (file_length - part * chunk_size);
-    if (size != expected) return false;
+    if (size != Protocol::expectedPartSize(part, file_length, chunk_size)) return false;
     if (static_cast<size_t>(length) < size + TRANSFER_HEADER) return false;
 
     parts.insert(part);
@@ -138,6 +115,64 @@ bool handleTransfer(const char* buf, int64_t length) {
 bool fileExists(const std::string& path) {
     std::ifstream f(path);
     return f.good();
+}
+
+// Write len bytes to a randomly-named temp beside `target`, then rename onto it.
+// The random suffix keeps a hostile sender from predicting the temp path, and on
+// POSIX O_EXCL|O_NOFOLLOW means a symlink planted at that path is never followed.
+// Returns a process exit code; on rename failure the verified temp is kept.
+int writeVerified(const std::string& target, const char* data, size_t len) {
+    std::random_device rd;
+    char suffix[24];
+    snprintf(suffix, sizeof(suffix), ".part.%08x%08x",
+             static_cast<unsigned>(rd()), static_cast<unsigned>(rd()));
+    const std::string tmp = target + suffix;
+
+    #if defined(_WIN32) || defined(_WIN64)
+    std::ofstream out(tmp, std::ofstream::binary | std::ofstream::trunc);
+    if (!out.is_open()) {
+        std::cerr << "Error: Can't open output file " << tmp << std::endl;
+        return 2;
+    }
+    out.write(data, static_cast<std::streamsize>(len));
+    out.close();
+    if (!out) {
+        std::cerr << "Error: Failed to write output file " << tmp << std::endl;
+        std::remove(tmp.c_str());
+        return 2;
+    }
+    std::remove(target.c_str());  // rename won't clobber on Windows
+    #else
+    int fd = open(tmp.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0644);
+    if (fd < 0) {
+        std::cerr << "Error: Can't create output file " << tmp << std::endl;
+        return 2;
+    }
+    bool ok = true;
+    for (size_t off = 0; off < len; ) {
+        ssize_t w = write(fd, data + off, len - off);
+        if (w < 0) {
+            if (errno == EINTR) continue;  // interrupted by a signal — retry
+            ok = false;
+            break;
+        }
+        if (w == 0) { ok = false; break; }  // not expected for a regular file
+        off += static_cast<size_t>(w);
+    }
+    if (close(fd) != 0) ok = false;
+    if (!ok) {
+        std::cerr << "Error: Failed to write output file " << tmp << std::endl;
+        std::remove(tmp.c_str());
+        return 2;
+    }
+    #endif
+
+    if (std::rename(tmp.c_str(), target.c_str()) != 0) {
+        std::cerr << "Error: Failed to finalize " << target
+                  << "; verified data kept at " << tmp << std::endl;
+        return 2;
+    }
+    return 0;
 }
 
 // Verify the reassembled file against the announced digest and write it out.
@@ -163,39 +198,11 @@ int verifyAndWrite() {
         return 2;
     }
 
-    // Write to a temporary and rename on success, so an interrupted write never
-    // leaves a truncated file under the target name.
-    const std::string tmp = fileName + ".part";
-    std::ofstream output(tmp, std::ofstream::binary | std::ofstream::trunc);
-    if (!output.is_open()) {
-        std::cerr << "Error: Can't open output file " << tmp << std::endl;
+    int wc = writeVerified(fileName, file, file_length);
+    if (wc != 0) {
         delete[] file;
         file = nullptr;
-        return 2;
-    }
-    output.write(file, static_cast<std::streamsize>(file_length));
-    output.close();
-    if (!output) {
-        std::cerr << "Error: Failed to write output file " << tmp << std::endl;
-        std::remove(tmp.c_str());
-        delete[] file;
-        file = nullptr;
-        return 2;
-    }
-    // On POSIX rename() atomically replaces the target, so no pre-remove is
-    // needed. On Windows rename() refuses to overwrite, so drop the target
-    // first (only meaningful with --overwrite, since otherwise it does not exist).
-    #if defined(_WIN32) || defined(_WIN64)
-    std::remove(fileName.c_str());
-    #endif
-    if (std::rename(tmp.c_str(), fileName.c_str()) != 0) {
-        // Keep the verified .part so the transfer is not lost — the RAM copy is
-        // freed below, so this file is the only remaining copy of the data.
-        std::cerr << "Error: Failed to finalize " << fileName
-                  << "; verified data kept at " << tmp << std::endl;
-        delete[] file;
-        file = nullptr;
-        return 2;
+        return wc;
     }
 
     double secs = reporter.elapsed();
@@ -295,10 +302,10 @@ bool announceValid(size_t announced, size_t chunk, int& exit_code) {
         return false;
     }
     // Chunk size must be in the sender's valid --mtu range. The lower bound
-    // matters for safety: parts = file_length / chunk_size, so a forged chunk
-    // size of 1 would make getEmptyParts() build a multi-billion-entry vector
-    // and OOM/crash the receiver from two tiny packets.
-    if (chunk < 64 || chunk > 65507) {
+    // matters for safety: parts = file_length / chunk_size, so a forged tiny
+    // chunk would make getEmptyParts() build a multi-billion-entry vector and
+    // OOM/crash the receiver from two tiny packets.
+    if (chunk < Protocol::MIN_CHUNK || chunk > Protocol::MAX_CHUNK) {
         std::cerr << "Error: Sender announced invalid chunk size " << chunk << std::endl;
         exit_code = 2;
         return false;
@@ -372,7 +379,7 @@ bool handleNewPacket(char*& buf, size_t& bufcap, int64_t length, int& exit_code)
     file_length  = announced;
     chunk_size   = incoming_cs;
     memcpy(expected_hash, buf + 24, 32);
-    announced_name = sanitizeName(std::string(buf + NEW_PACKET_FIXED, name_len));
+    announced_name = Protocol::sanitizeName(std::string(buf + NEW_PACKET_FIXED, name_len));
     if (!fileNameFromCli) fileName = announced_name;
 
     if (!allocateBuffers(buf, bufcap, exit_code)) return false;

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -38,11 +38,19 @@ namespace Utils {
     }
 
     /**
-     * Encode an unsigned integer into a big-endian byte sequence.
+     * Encode an unsigned integer into a big-endian byte sequence. Bytes beyond
+     * the width of size_t are written as 0 rather than shifting past the type
+     * width, which is undefined behaviour (count > sizeof(size_t) is used by the
+     * unit tests and would otherwise trip UBSan).
      */
     inline void writeBytesFromNumber(char* buffer, size_t number, int count) {
+        constexpr int bits = static_cast<int>(sizeof(size_t) * 8);
         for (int i = 0; i < count; i++) {
-            buffer[count - i - 1] = static_cast<char>(number >> (i * 8));
+            int shift = i * 8;
+            unsigned char byte = (shift < bits)
+                ? static_cast<unsigned char>(number >> shift)
+                : 0u;
+            buffer[count - i - 1] = static_cast<char>(byte);
         }
     }
 }

--- a/tests/Tests.cpp
+++ b/tests/Tests.cpp
@@ -2,6 +2,8 @@
 
 #include "../src/Utils.hpp"
 #include "../src/Sha256.hpp"
+#include "../src/Protocol.hpp"
+#include "../src/Progress.hpp"
 
 #include <string>
 #include <cstring>
@@ -61,6 +63,75 @@ TEST(Sha256, DetectsSingleBitFlip) {
     std::string b = a;
     b[100] ^= 0x01;
     EXPECT_NE(sha256Hex(a), sha256Hex(b));
+}
+
+// --- Protocol helpers -------------------------------------------------------
+
+TEST(Protocol, SanitizeNameStripsDirectories) {
+    EXPECT_EQ(Protocol::sanitizeName("photo.jpg"), "photo.jpg");
+    EXPECT_EQ(Protocol::sanitizeName("a/b/c.txt"), "c.txt");
+    EXPECT_EQ(Protocol::sanitizeName("../../etc/passwd"), "passwd");
+    EXPECT_EQ(Protocol::sanitizeName("dir\\sub\\file.bin"), "file.bin");
+}
+
+TEST(Protocol, SanitizeNameRejectsDangerous) {
+    EXPECT_EQ(Protocol::sanitizeName(""), "file.out");
+    EXPECT_EQ(Protocol::sanitizeName("."), "file.out");
+    EXPECT_EQ(Protocol::sanitizeName(".."), "file.out");
+    EXPECT_EQ(Protocol::sanitizeName("C:evil"), "file.out");          // drive-relative
+    EXPECT_EQ(Protocol::sanitizeName("notes.txt:hidden"), "file.out"); // ADS
+    EXPECT_EQ(Protocol::sanitizeName("CON"), "file.out");             // device
+    EXPECT_EQ(Protocol::sanitizeName("com1.txt"), "file.out");        // device + ext, any case
+    EXPECT_EQ(Protocol::sanitizeName("LPT9"), "file.out");
+}
+
+TEST(Protocol, SanitizeNameAllowsNormalNames) {
+    EXPECT_EQ(Protocol::sanitizeName("console.log"), "console.log");  // not a device
+    EXPECT_EQ(Protocol::sanitizeName("com10.bin"), "com10.bin");      // COM10 is not reserved
+}
+
+TEST(Protocol, TotalPartsBoundaries) {
+    EXPECT_EQ(Protocol::totalParts(1, 1500), 1u);
+    EXPECT_EQ(Protocol::totalParts(1500, 1500), 1u);
+    EXPECT_EQ(Protocol::totalParts(1501, 1500), 2u);
+    EXPECT_EQ(Protocol::totalParts(3000, 1500), 2u);
+}
+
+TEST(Protocol, ExpectedPartSize) {
+    // 3001 bytes over 1500-byte chunks -> parts of 1500, 1500, 1.
+    EXPECT_EQ(Protocol::expectedPartSize(0, 3001, 1500), 1500u);
+    EXPECT_EQ(Protocol::expectedPartSize(1, 3001, 1500), 1500u);
+    EXPECT_EQ(Protocol::expectedPartSize(2, 3001, 1500), 1u);
+    // Exact multiple: last part is a full chunk.
+    EXPECT_EQ(Protocol::expectedPartSize(1, 3000, 1500), 1500u);
+}
+
+TEST(Protocol, AnnounceInRange) {
+    const size_t maxFile = 4ULL * 1024 * 1024 * 1024;
+    EXPECT_TRUE(Protocol::announceInRange(1, 64, maxFile));
+    EXPECT_TRUE(Protocol::announceInRange(maxFile, 65507, maxFile));
+    EXPECT_FALSE(Protocol::announceInRange(0, 1500, maxFile));         // empty file
+    EXPECT_FALSE(Protocol::announceInRange(maxFile + 1, 1500, maxFile)); // too big
+    EXPECT_FALSE(Protocol::announceInRange(1000, 63, maxFile));        // chunk too small (OOM guard)
+    EXPECT_FALSE(Protocol::announceInRange(1000, 65508, maxFile));     // chunk too big
+}
+
+// --- Progress formatting ----------------------------------------------------
+
+TEST(Progress, HumanBytes) {
+    EXPECT_EQ(Progress::humanBytes(0), "0 B");
+    EXPECT_EQ(Progress::humanBytes(512), "512 B");
+    EXPECT_EQ(Progress::humanBytes(1024), "1.0 KiB");
+    EXPECT_EQ(Progress::humanBytes(1536), "1.5 KiB");
+    EXPECT_EQ(Progress::humanBytes(1024ULL * 1024), "1.0 MiB");
+    EXPECT_EQ(Progress::humanBytes(1024ULL * 1024 * 1024), "1.0 GiB");
+}
+
+TEST(Progress, HumanDuration) {
+    EXPECT_EQ(Progress::humanDuration(3.2), "3.2s");
+    EXPECT_EQ(Progress::humanDuration(63), "1m03s");
+    EXPECT_EQ(Progress::humanDuration(-5), "0.0s");     // clamped, no negative
+    EXPECT_EQ(Progress::humanDuration(1e12), ">99h");   // clamped, no int overflow/UB
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Заход «инфраструктура/качество».

## Что сделано

- **ASan/UBSan-джоб в CI** — новый job собирает с `-fsanitize=address,undefined` и гоняет весь набор. Он **сразу поймал реальный UB** — сдвиг за разрядность `size_t` в `Utils::writeBytesFromNumber` при `count=16` (юнит-тест сам его вызывал). Исправлено (байты за пределами ширины пишутся 0).
- **Тестируемые протокольные хелперы** — чистая (без сокетов) логика фрейминга/валидации вынесена в `src/Protocol.hpp` (`totalParts`, `expectedPartSize`, `announceInRange`, `sanitizeName`, границы chunk_size). Добавлены юнит-тесты: санитизация имени (traversal, `:`, устройства), размеры частей, валидация, форматтеры прогресса. Всего 29 unit-тестов (было ~22).
- **Безопасная запись файла** — `writeVerified()`: рандомное имя temp (отправитель не предугадает путь), на POSIX создание с `O_EXCL|O_NOFOLLOW` (симлинк не следуется), затем `rename`. Закрывает отложенные low-находки про предсказуемый `.part` и symlink-follow.

## Проверка

- Полный `ctest` зелёный в Release **и под ASan/UBSan** (29 unit + e2e + e2e_lossy); lizard 0 warnings; cppcheck/cpplint чисто; ручная передача (файл получен, sha совпал, temp не остался).
- **Адверсариальное ревью (3 ревьюера + скептики): 0 confirmed** — все находки low, disputed или killed (divide-by-zero недостижим после валидации, EINTR без signal-хендлеров, Windows-окно recoverable). Применил 2 дешёвых defensive-фикса (EINTR-retry, guard от деления на ноль).

## Осталось (low, отложено)
Windows использует `remove`+`rename` (не атомарно, но данные recoverable под temp) — можно заменить на `MoveFileEx`/`ReplaceFile` отдельно; fsync перед rename для durability при power-loss.