### PR TITLE
Add an IP multicast destination mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ LAN at once, with automatic retransmission of dropped packets.
 ## Features
 
 - Broadcast to every host on a LAN with a single transmission
-- Unicast mode for point-to-point transfer
+- Unicast mode for point-to-point transfer, and IP multicast for one-to-many
+  without flooding the whole VLAN
 - Automatic retransmission of lost packets
 - End-to-end SHA-256 integrity check — a corrupted file is rejected, not saved
 - File name travels with the transfer, so `receive` needs no arguments
@@ -88,6 +89,7 @@ filecast receive [file] [options]    # receive a file (default: name from sender
 | --------- | ------- | ----- | ----------- |
 | `<file>` (positional) | — (send) / name from sender (receive) | — | File to send, or where to save it. `-f, --file` is an alias |
 | `--to`        | broadcast  | IPv4 | Send to one host instead of LAN broadcast |
+| `--multicast` | broadcast  | IPv4 multicast | Use an IP multicast group (224.0.0.0-239.255.255.255) instead of broadcast |
 | `-p, --port`  | `33333`    | 1..65535 | Destination port for outgoing packets |
 | `--bind-port` | `33333`    | 1..65535 | Local port to bind on |
 | `--mtu`       | `1500`     | 64..65507 | Max packet size in bytes |
@@ -119,6 +121,18 @@ filecast receive [file] [options]    # receive a file (default: name from sender
 
 # On 10.0.0.42 (receiver broadcasts its RESENDs by default)
 ./filecast receive album.zip
+```
+
+**IP multicast** (one-to-many without flooding every host on the VLAN — NICs of
+non-members drop the traffic in hardware and IGMP-snooping switches forward it
+only to subscribers). Sender and every receiver use the same group:
+
+```sh
+# On the sender host
+./filecast send album.zip --multicast 239.1.2.3
+
+# On every receiver host (same group)
+./filecast receive album.zip --multicast 239.1.2.3
 ```
 
 **Loopback test** (sender and receiver on the same host — useful for

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -27,6 +27,10 @@ namespace {
 // Result of picking the subcommand off argv[1].
 enum class Command { Send, Receive, Handled };
 
+// How packets are addressed: LAN broadcast (default), one host (--to), or an
+// IP multicast group (--multicast).
+enum class SendMode { Broadcast, Unicast, Multicast };
+
 // Everything parsed from the CLI, validated and ready to act on.
 struct CliOptions {
     int         mtu       = 1500;
@@ -37,8 +41,8 @@ struct CliOptions {
     int64_t     pace_us   = 0;          // inter-packet pause derived from rate/delay
     std::string file;
     bool        file_from_cli = false;  // true if the user named the file
-    bool        use_broadcast = true;   // false when --to <ip> is given
-    std::string target;                 // destination IP for unicast
+    SendMode    mode      = SendMode::Broadcast;
+    std::string target;                 // IP for unicast / group for multicast
     bool        verbose   = false;      // per-packet logging instead of a bar
     bool        overwrite = false;      // allow overwriting an existing file
 };
@@ -52,6 +56,7 @@ void buildOptions(cxxopts::Options& options) {
     options.add_options()
         ("f,file",    "File to send, or where to save it when receiving", cxxopts::value<std::string>())
         ("to",        "Send to this IPv4 address instead of LAN broadcast", cxxopts::value<std::string>())
+        ("multicast", "Use this IPv4 multicast group (224.0.0.0-239.255.255.255)", cxxopts::value<std::string>())
         ("p,port",    "Destination UDP port",                 cxxopts::value<int>()->default_value("33333"))
         ("bind-port", "Local UDP port to bind on",            cxxopts::value<int>()->default_value("33333"))
         ("mtu",       "Max packet size in bytes",             cxxopts::value<int>()->default_value("1500"))
@@ -74,7 +79,8 @@ void printUsage(cxxopts::Options& options, std::ostream& os) {
        << "\nExamples:\n"
        << "  filecast send photo.jpg\n"
        << "  filecast receive\n"
-       << "  filecast send photo.jpg --to 192.168.1.50 --rate 500\n";
+       << "  filecast send photo.jpg --to 192.168.1.50 --rate 500\n"
+       << "  filecast send photo.jpg --multicast 239.1.2.3\n";
 }
 
 // Peel the subcommand off argv[1], handling global --help/--version. Sets
@@ -167,9 +173,74 @@ bool collectOptions(const cxxopts::ParseResult& result, bool is_sender, CliOptio
     opt.file          = has_file ? result["file"].as<std::string>() : std::string();
     opt.file_from_cli = has_file;
 
-    opt.use_broadcast = (result.count("to") == 0);
-    opt.target = opt.use_broadcast ? std::string() : result["to"].as<std::string>();
+    // Destination mode: default broadcast, --to <ip> unicast, --multicast <group>.
+    if (result.count("to") && result.count("multicast")) {
+        std::cerr << "Error: --to and --multicast are mutually exclusive" << std::endl;
+        return false;
+    }
+    if (result.count("multicast")) {
+        opt.mode = SendMode::Multicast;
+        opt.target = result["multicast"].as<std::string>();
+    } else if (result.count("to")) {
+        opt.mode = SendMode::Unicast;
+        opt.target = result["to"].as<std::string>();
+    } else {
+        opt.mode = SendMode::Broadcast;
+    }
     return true;
+}
+
+// Fill broadcast_address with the destination and apply mode-specific options
+// (enable SO_BROADCAST / validate a multicast group). Returns 0 on success.
+int configureDestination(const CliOptions& opt) {
+    broadcast_address.sin_family = AF_INET;
+    broadcast_address.sin_port = htons(static_cast<uint16_t>(opt.port));
+
+    if (opt.mode == SendMode::Broadcast) {
+        int broadcastEnable = 1;
+        if (setsockopt(_socket, SOL_SOCKET, SO_BROADCAST,
+                       reinterpret_cast<const char*>(&broadcastEnable),
+                       sizeof(broadcastEnable)) != 0) {
+            std::cerr << "Error: Can't get access to broadcast" << std::endl;
+            return 1;
+        }
+        if (verbose) std::cout << "Ok: Got access to broadcast" << std::endl;
+        broadcast_address.sin_addr.s_addr = INADDR_BROADCAST;
+        return 0;
+    }
+
+    const char* flag = (opt.mode == SendMode::Multicast) ? "--multicast" : "--to";
+    if (inet_pton(AF_INET, opt.target.c_str(), &broadcast_address.sin_addr) != 1) {
+        std::cerr << "Error: " << flag << " must be a valid IPv4 address" << std::endl;
+        return 1;
+    }
+    if (opt.mode == SendMode::Multicast) {
+        // 224.0.0.0/4 — top four bits are 1110. Default IP_MULTICAST_TTL (1) and
+        // IP_MULTICAST_LOOP (on) suit a single subnet and same-host tests, so we
+        // leave them unset and avoid the platform-specific option-type quirks.
+        uint32_t host = ntohl(broadcast_address.sin_addr.s_addr);
+        if ((host >> 28) != 0xE) {
+            std::cerr << "Error: --multicast must be in 224.0.0.0-239.255.255.255" << std::endl;
+            return 1;
+        }
+    }
+    return 0;
+}
+
+// Join the multicast group so this socket receives packets addressed to it
+// (both the receiver's data and the sender's view of RESENDs). No-op otherwise.
+int joinMulticast(const CliOptions& opt) {
+    if (opt.mode != SendMode::Multicast) return 0;
+    struct ip_mreq mreq;
+    mreq.imr_multiaddr = broadcast_address.sin_addr;
+    mreq.imr_interface.s_addr = INADDR_ANY;
+    if (setsockopt(_socket, IPPROTO_IP, IP_ADD_MEMBERSHIP,
+                   reinterpret_cast<const char*>(&mreq), sizeof(mreq)) != 0) {
+        std::cerr << "Error: Can't join multicast group " << opt.target << std::endl;
+        return 1;
+    }
+    if (verbose) std::cout << "Ok: Joined multicast group " << opt.target << std::endl;
+    return 0;
 }
 
 // Create the socket, apply options and bind. Returns a process exit code
@@ -202,24 +273,8 @@ int setupSocket(const CliOptions& opt) {
 
     memcpy(&server_address, &client_address, sizeof(server_address));
 
-    broadcast_address.sin_family = AF_INET;
-    broadcast_address.sin_port = htons(static_cast<uint16_t>(opt.port));
-
-    if (opt.use_broadcast) {
-        int broadcastEnable = 1;
-        if (setsockopt(_socket, SOL_SOCKET, SO_BROADCAST,
-                       reinterpret_cast<const char*>(&broadcastEnable),
-                       sizeof(broadcastEnable)) != 0) {
-            std::cerr << "Error: Can't get access to broadcast" << std::endl;
-            cleanupAndExit(1);
-        }
-        if (verbose) std::cout << "Ok: Got access to broadcast" << std::endl;
-        broadcast_address.sin_addr.s_addr = INADDR_BROADCAST;
-    } else {
-        if (inet_pton(AF_INET, opt.target.c_str(), &broadcast_address.sin_addr) != 1) {
-            std::cerr << "Error: --to must be a valid IPv4 address" << std::endl;
-            cleanupAndExit(1);
-        }
+    if (configureDestination(opt) != 0) {
+        cleanupAndExit(1);
     }
 
     if (bind(_socket, reinterpret_cast<sockaddr*>(&client_address), sizeof(client_address)) != 0) {
@@ -227,6 +282,12 @@ int setupSocket(const CliOptions& opt) {
         cleanupAndExit(1);
     }
     if (verbose) std::cout << "Ok: Socket bound" << std::endl;
+
+    // Joining the group must happen after bind so the membership sticks to the
+    // bound port. Broadcast/unicast modes are no-ops here.
+    if (joinMulticast(opt) != 0) {
+        cleanupAndExit(1);
+    }
 
     #if defined(_WIN32) || defined(_WIN64)
     DWORD tv = 1000;  // user timeout in milliseconds [ms]

--- a/src/Utils.hpp
+++ b/src/Utils.hpp
@@ -17,6 +17,7 @@
 #define INVALID_SOCKET (-1)
 #include <unistd.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>   // ip_mreq, IP_ADD_MEMBERSHIP, IPPROTO_IP (not guaranteed via arpa/inet.h)
 #define CLOSE_SOCKET(s) close(s)
 #define CLEANUP_NETWORK() ((void)0)
 #endif

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -34,6 +34,11 @@ run_test() {
     local recv_log="$WORKDIR/recv-$label.log"
     local send_log="$WORKDIR/send-$label.log"
 
+    # Destination flags: unicast loopback by default; overridable (e.g. multicast).
+    # Split into an array so a multi-word DEST expands into separate arguments.
+    local dest
+    read -ra dest <<< "${DEST:---to 127.0.0.1}"
+
     echo "==> [$label] generating ${size_kb} KiB file"
     dd if=/dev/urandom of="$src" bs=1024 count="$size_kb" status=none
 
@@ -41,7 +46,7 @@ run_test() {
     # --delay-ms 0 removes the inter-packet pause that the protocol uses on real
     # LANs to avoid overrunning receivers; on loopback it just slows tests down.
     echo "==> [$label] starting receiver (bind=$recv_port, target=$send_port)"
-    "$BINARY" receive "$dst" --to 127.0.0.1 \
+    "$BINARY" receive "$dst" "${dest[@]}" \
               --bind-port "$recv_port" --port "$send_port" --ttl "$recv_ttl" \
               --delay-ms 0 \
         > "$recv_log" 2>&1 &
@@ -52,7 +57,7 @@ run_test() {
 
     # Sender listens on $send_port, sends TRANSFER to $recv_port (receiver's bind).
     echo "==> [$label] starting sender (bind=$send_port, target=$recv_port)"
-    if ! "$BINARY" send "$src" --to 127.0.0.1 \
+    if ! "$BINARY" send "$src" "${dest[@]}" \
                    --bind-port "$send_port" --port "$recv_port" --ttl "$send_ttl" \
                    --delay-ms 0 \
             > "$send_log" 2>&1; then
@@ -106,6 +111,36 @@ run_test "small" 50    33401 33402 3 1
 
 # Large file: 2 MiB -> ~1400 parts at default MTU 1500.
 run_test "large" 2048  33403 33404 3 1
+
+# Multicast: same protocol over an IP multicast group. Some CI/loopback setups
+# lack multicast routing, so first probe whether a group datagram is delivered
+# at all. Only when the environment supports it do we run the transfer as a hard
+# test — so a real regression in the join/addressing logic fails the suite,
+# rather than being masked as "unavailable".
+mc_available() {
+    command -v python3 >/dev/null 2>&1 || return 1
+    python3 - <<'PY' 2>/dev/null
+import socket, struct, sys
+group, port = "239.255.42.99", 34099
+try:
+    r = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    r.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    r.bind(("", port))
+    mreq = struct.pack("4sl", socket.inet_aton(group), socket.INADDR_ANY)
+    r.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+    r.settimeout(1.0)
+    socket.socket(socket.AF_INET, socket.SOCK_DGRAM).sendto(b"probe", (group, port))
+    sys.exit(0 if r.recvfrom(16)[0] == b"probe" else 1)
+except Exception:
+    sys.exit(1)
+PY
+}
+
+if mc_available; then
+    DEST="--multicast 239.255.42.99" run_test "multicast" 50 33405 33406 3 1
+else
+    echo "SKIP: [multicast] not available in this environment"
+fi
 
 echo
 echo "All E2E tests passed."


### PR DESCRIPTION
Первый из двух технических PR (второй — шифрование PSK). Добавляет третий режим назначения `--multicast <группа>` наряду с broadcast (по умолчанию) и unicast (`--to`).

## Зачем
One-to-many доставка **без флуда всего VLAN**: сетевые карты не-участников отбрасывают трафик аппаратно, а IGMP-snooping свитчи шлют только подписчикам. Прямое преимущество над broadcast (и то, что делают udpcast/UFTP).

## Как
- Enum `SendMode` заменил булев флаг; `--to` и `--multicast` взаимоисключающие.
- `configureDestination()` валидирует группу (224.0.0.0/4); `joinMulticast()` делает `IP_ADD_MEMBERSHIP` после bind на обеих сторонах (receiver — чтобы получать данные, sender — чтобы видеть RESEND). Дефолты `IP_MULTICAST_TTL=1`/`LOOP=on` подходят для одной подсети и loopback-тестов, поэтому не трогаются.
- e2e **пробит доступность multicast** в окружении: если группа реально доставляется — прогон идёт как hard-тест (регрессия join/адресации роняет suite), иначе SKIP.

## Проверка
- Полный `ctest` зелёный (multicast e2e на loopback — файл дошёл, sha совпал); валидация (не-multicast адрес отклонён, `--to`+`--multicast` → ошибка); lizard 0 warnings; cppcheck/cpplint/shellcheck чисто.
- **Адверсариальное ревью (3 ревьюера + скептики): 1 confirmed low** — multicast e2e маскировал fail как SKIP; **исправлено** (probe + hard-тест). Остальное disputed/killed (INADDR_ANY interface — документировано для single-subnet; netinet include — добавил явно).

## Осталось (low)
Интерфейс выбирается ядром (`INADDR_ANY`, без `IP_MULTICAST_IF`) — на мультихоумных хостах может уйти не на тот NIC; для single-subnet (заявленная ниша) работает. Кандидат на `--iface` отдельно.