### PR TITLE
Add --iface to pin the multicast interface on multi-homed hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ filecast receive [file] [options]    # receive a file (default: name from sender
 | `<file>` (positional) | — (send) / name from sender (receive) | — | File to send, or where to save it. `-f, --file` is an alias |
 | `--to`        | broadcast  | IPv4 | Send to one host instead of LAN broadcast |
 | `--multicast` | broadcast  | IPv4 multicast | Use an IP multicast group (224.0.0.0-239.255.255.255) instead of broadcast |
+| `--iface`     | system-chosen | IPv4 | Multicast interface — the local NIC's IPv4 to send/receive the group on (`--multicast` only) |
 | `-p, --port`  | `33333`    | 1..65535 | Destination port for outgoing packets |
 | `--bind-port` | `33333`    | 1..65535 | Local port to bind on |
 | `--mtu`       | `1500`     | 64..65507 | Max packet size in bytes |
@@ -135,6 +136,14 @@ only to subscribers). Sender and every receiver use the same group:
 
 # On every receiver host (same group)
 ./filecast receive album.zip --multicast 239.1.2.3
+```
+
+On a multi-homed host (several NICs), pin the group to a specific interface by
+its local IPv4 so the kernel doesn't pick the wrong one:
+
+```sh
+./filecast send album.zip --multicast 239.1.2.3 --iface 192.168.1.10
+./filecast receive album.zip --multicast 239.1.2.3 --iface 192.168.1.10
 ```
 
 **Loopback test** (sender and receiver on the same host — useful for

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -43,6 +43,9 @@ struct CliOptions {
     bool        file_from_cli = false;  // true if the user named the file
     SendMode    mode      = SendMode::Broadcast;
     std::string target;                 // IP for unicast / group for multicast
+    bool        has_iface = false;      // --iface given (multicast interface pinned)
+    std::string iface;                  // its original string, for messages
+    struct in_addr iface_addr{};        // parsed --iface (IP_MULTICAST_IF / imr_interface)
     bool        verbose   = false;      // per-packet logging instead of a bar
     bool        overwrite = false;      // allow overwriting an existing file
     bool        resume    = false;      // resume from a .part snapshot
@@ -58,6 +61,7 @@ void buildOptions(cxxopts::Options& options) {
         ("f,file",    "File to send, or where to save it when receiving", cxxopts::value<std::string>())
         ("to",        "Send to this IPv4 address instead of LAN broadcast", cxxopts::value<std::string>())
         ("multicast", "Use this IPv4 multicast group (224.0.0.0-239.255.255.255)", cxxopts::value<std::string>())
+        ("iface",     "Multicast interface IPv4 address (which NIC to use; --multicast only)", cxxopts::value<std::string>())
         ("p,port",    "Destination UDP port",                 cxxopts::value<int>()->default_value("33333"))
         ("bind-port", "Local UDP port to bind on",            cxxopts::value<int>()->default_value("33333"))
         ("mtu",       "Max packet size in bytes",             cxxopts::value<int>()->default_value("1500"))
@@ -139,6 +143,40 @@ bool validateNumericFlags(const CliOptions& opt) {
     return true;
 }
 
+// Resolve the destination mode (broadcast / --to unicast / --multicast group)
+// and the optional --iface into opt. Prints and returns false on any problem.
+bool collectDestination(const cxxopts::ParseResult& result, CliOptions& opt) {
+    if (result.count("to") && result.count("multicast")) {
+        std::cerr << "Error: --to and --multicast are mutually exclusive" << std::endl;
+        return false;
+    }
+    if (result.count("multicast")) {
+        opt.mode = SendMode::Multicast;
+        opt.target = result["multicast"].as<std::string>();
+    } else if (result.count("to")) {
+        opt.mode = SendMode::Unicast;
+        opt.target = result["to"].as<std::string>();
+    } else {
+        opt.mode = SendMode::Broadcast;
+    }
+
+    // --iface pins the NIC used for multicast (send + join). It has no meaning
+    // for broadcast/unicast, so reject it there rather than silently ignore it.
+    if (result.count("iface")) {
+        if (opt.mode != SendMode::Multicast) {
+            std::cerr << "Error: --iface only applies to --multicast" << std::endl;
+            return false;
+        }
+        opt.iface = result["iface"].as<std::string>();
+        if (inet_pton(AF_INET, opt.iface.c_str(), &opt.iface_addr) != 1) {
+            std::cerr << "Error: --iface must be a valid IPv4 address" << std::endl;
+            return false;
+        }
+        opt.has_iface = true;
+    }
+    return true;
+}
+
 // Fill a CliOptions from the parsed result and validate it. Prints and returns
 // false on any problem.
 bool collectOptions(const cxxopts::ParseResult& result, bool is_sender, CliOptions& opt) {
@@ -176,21 +214,7 @@ bool collectOptions(const cxxopts::ParseResult& result, bool is_sender, CliOptio
     opt.file          = has_file ? result["file"].as<std::string>() : std::string();
     opt.file_from_cli = has_file;
 
-    // Destination mode: default broadcast, --to <ip> unicast, --multicast <group>.
-    if (result.count("to") && result.count("multicast")) {
-        std::cerr << "Error: --to and --multicast are mutually exclusive" << std::endl;
-        return false;
-    }
-    if (result.count("multicast")) {
-        opt.mode = SendMode::Multicast;
-        opt.target = result["multicast"].as<std::string>();
-    } else if (result.count("to")) {
-        opt.mode = SendMode::Unicast;
-        opt.target = result["to"].as<std::string>();
-    } else {
-        opt.mode = SendMode::Broadcast;
-    }
-    return true;
+    return collectDestination(result, opt);
 }
 
 // Fill broadcast_address with the destination and apply mode-specific options
@@ -226,6 +250,19 @@ int configureDestination(const CliOptions& opt) {
             std::cerr << "Error: --multicast must be in 224.0.0.0-239.255.255.255" << std::endl;
             return 1;
         }
+        // Pin outgoing multicast (the sender's TRANSFERs, the receiver's RESENDs)
+        // to the requested NIC. Without this the kernel picks the egress
+        // interface, which on a multi-homed host may be the wrong one.
+        if (opt.has_iface &&
+            setsockopt(_socket, IPPROTO_IP, IP_MULTICAST_IF,
+                       reinterpret_cast<const char*>(&opt.iface_addr),
+                       sizeof(opt.iface_addr)) != 0) {
+            std::cerr << "Error: Can't set multicast interface " << opt.iface << std::endl;
+            return 1;
+        }
+        if (opt.has_iface && verbose) {
+            std::cout << "Ok: Multicast interface " << opt.iface << std::endl;
+        }
     }
     return 0;
 }
@@ -236,7 +273,8 @@ int joinMulticast(const CliOptions& opt) {
     if (opt.mode != SendMode::Multicast) return 0;
     struct ip_mreq mreq;
     mreq.imr_multiaddr = broadcast_address.sin_addr;
-    mreq.imr_interface.s_addr = INADDR_ANY;
+    // Join on the requested NIC, or let the kernel choose (INADDR_ANY).
+    mreq.imr_interface.s_addr = opt.has_iface ? opt.iface_addr.s_addr : INADDR_ANY;
     if (setsockopt(_socket, IPPROTO_IP, IP_ADD_MEMBERSHIP,
                    reinterpret_cast<const char*>(&mreq), sizeof(mreq)) != 0) {
         std::cerr << "Error: Can't join multicast group " << opt.target << std::endl;

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -142,6 +142,34 @@ else
     echo "SKIP: [multicast] not available in this environment"
 fi
 
+# --iface guard rails: the flag only applies to multicast and must be a valid
+# IPv4. These are pure argument checks (no sockets), so they run everywhere and
+# pin the validation added alongside --iface. Assert the *specific* rejection
+# message rather than just a non-zero exit — otherwise, on a host without
+# multicast routing, a broken validation could fall through to a failed group
+# join (also exit 1) and pass for the wrong reason.
+run_iface_validation() {
+    local f="$WORKDIR/iface-src.bin"
+    echo "iface-test" > "$f"
+    local out=0 err
+
+    err="$("$BINARY" send "$f" --iface 10.0.0.1 2>&1 >/dev/null || true)"
+    grep -q "only applies to --multicast" <<<"$err" || {
+        echo "FAIL: [iface] --iface without --multicast not rejected: $err"; out=1; }
+
+    err="$("$BINARY" send "$f" --to 127.0.0.1 --iface 10.0.0.1 2>&1 >/dev/null || true)"
+    grep -q "only applies to --multicast" <<<"$err" || {
+        echo "FAIL: [iface] --iface with unicast --to not rejected: $err"; out=1; }
+
+    err="$("$BINARY" send "$f" --multicast 239.1.2.3 --iface not-an-ip 2>&1 >/dev/null || true)"
+    grep -q -- "--iface must be a valid IPv4 address" <<<"$err" || {
+        echo "FAIL: [iface] invalid --iface IPv4 not rejected: $err"; out=1; }
+
+    [ "$out" -eq 0 ] && echo "PASS: [iface] --iface guard rails reject misuse"
+    return "$out"
+}
+run_iface_validation
+
 # Resume: interrupt a slow receive with SIGINT, then finish it with --resume.
 # Timing-based, so if no snapshot lands (transfer finished or nothing arrived in
 # the window) it SKIPs; but once a snapshot exists, resume must succeed or FAIL.


### PR DESCRIPTION
## What

Adds `--iface <ipv4>` to `filecast`, pinning which local NIC carries an IP multicast transfer. Previously the group join and multicast egress both used `INADDR_ANY`, so the kernel chose the interface — on a host with several NICs (VPN + LAN, docker bridges, multiple physical ports) it can pick the wrong one and the transfer silently goes nowhere.

`--iface` pins **both directions**:
- `IP_MULTICAST_IF` — outgoing multicast (the sender's `TRANSFER`s and the receiver's `RESEND`s)
- `ip_mreq.imr_interface` — the group join (incoming)

```sh
filecast send   album.zip --multicast 239.1.2.3 --iface 192.168.1.10
filecast receive album.zip --multicast 239.1.2.3 --iface 192.168.1.10
```

## Behavior / validation

- Applies to `--multicast` only — rejected with a clear error for broadcast/unicast rather than silently ignored.
- Must be a valid IPv4 (`inet_pton`); a well-formed but non-local address is caught by the kernel at `setsockopt(IP_MULTICAST_IF)` (`EADDRNOTAVAIL`) before any transfer.
- Destination parsing extracted into `collectDestination()` to keep `collectOptions` under the complexity gate.

## Verification

- **Functional:** multicast transfer over loopback pinned with `--iface 127.0.0.1` — receiver logs `Multicast interface 127.0.0.1` + `Joined multicast group`, `sha256 verified`, bytes match.
- **Validation:** all four misuse paths rejected (`--iface` without multicast, with `--to`, invalid IPv4, with default broadcast).
- **e2e:** new guard-rail test asserts the *specific* rejection message (not just exit code), so it can't pass for the wrong reason on a no-multicast host.
- ctest green in Release and under ASan/UBSan; all functions CCN ≤ 14; cppcheck / cpplint / shellcheck clean.
- Adversarial review (11 agents): 0 confirmed, 3 low findings killed; 1 disputed test-robustness item addressed (the message-assertion above). Windows path is compile-checked in CI only.