### PR TITLE
Protocol v3: common 10-byte header (magic + version + type + session)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,10 @@ filecast send in.bin \
 ## How It Works
 
 The sender announces the file — size, SHA-256, name, and a random session id —
-then broadcasts it in MTU-sized chunks. After the announcement's `FINISH`
-marker, each receiver requests the chunks it missed, and every retransmission
-repairs all receivers that missed that part at once. The file is written out
-(atomically) only after its SHA-256 matches the announcement.
+then broadcasts it in MTU-sized chunks. Once the sender signals `FINISH`, each
+receiver requests the chunks it missed, and every retransmission repairs all
+receivers that missed that part at once. The file is written out (atomically)
+only after its SHA-256 matches the announcement.
 
 The full wire format lives in [docs/PROTOCOL.md](docs/PROTOCOL.md).
 
@@ -242,7 +242,7 @@ The snapshot is deleted once the file completes and its checksum verifies.
   interrupting a multi-gigabyte transfer adds a short exit delay while it flushes.
   The `.part`/`.part.idx` files use stable, predictable names in the working
   directory, so run the receiver from a directory only you can write to.
-- No authentication. Any host on the same LAN can send a `NEW_PACKET` and any
+- No authentication. Any host on the same LAN can announce a transfer and any
   receiver bound to the chosen port will accept it. The SHA-256 check catches
   accidental corruption, not a deliberately crafted stream.
 - No encryption yet. The payload travels as plaintext UDP; treat the LAN as

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,29 +1,47 @@
-# Filecast wire protocol (v2)
+# Filecast wire protocol (v3)
 
-Four packet types over UDP. All multi-byte fields are big-endian. Every packet
-carries a 32-bit session id chosen randomly by the sender, so a receiver
-ignores traffic from a different (or restarted) sender.
+Four packet types over UDP. All multi-byte fields are big-endian.
 
-## Packet layouts
+## Common header
 
-| Packet | Layout |
-| ------ | ------ |
-| `NEW_PACKET` | `"NEW_PACKET"` · version(2) · session(4) · file_size(4) · chunk_size(4) · sha256(32) · name_len(2) · name |
-| `TRANSFER` | `"TRANSFER"` · session(4) · part(4) · length(4) · data |
-| `FINISH` | `"FINISH"` · session(4) |
-| `RESEND` | `"RESEND"` · session(4) · part(4) |
+Every packet starts with the same 10-byte header:
+
+| Field | Size | Value |
+| ----- | ---- | ----- |
+| magic | 4 | `"FCST"` |
+| version | 1 | `3` |
+| type | 1 | `1` ANNOUNCE · `2` TRANSFER · `3` FINISH · `4` RESEND |
+| session | 4 | random id chosen by the sender per transfer |
+
+The magic keeps stray UDP traffic on the port from being misparsed (and is
+still recognizable to a human reading a tcpdump hex dump). The session id is
+stamped into every packet so a receiver ignores traffic from a different (or
+restarted) sender. The version travels in every packet — a receiver that sees
+the filecast magic with an unknown version reports it once and ignores the
+traffic, so a version-mixed LAN fails loudly instead of silently. The header
+layout itself is the compatibility contract: future protocol versions keep
+these 10 bytes.
+
+## Packet bodies
+
+| Packet | Body (after the common header) |
+| ------ | ------------------------------ |
+| `ANNOUNCE` | file_size(4) · chunk_size(4) · sha256(32) · name_len(2) · name |
+| `TRANSFER` | part(4) · length(4) · data |
+| `FINISH` | — |
+| `RESEND` | part(4) |
 
 ## Transfer sequence
 
-1. The sender broadcasts a `NEW_PACKET` announcing a random session id, the
-   total file size, the chunk size, the file's SHA-256, and its name.
+1. The sender broadcasts an `ANNOUNCE` carrying a random session id, the total
+   file size, the chunk size, the file's SHA-256, and its name.
 2. Each receiver latches that session, allocates a buffer, and clears its part
-   registry. Packets from any other session are ignored. The chunk size is
-   taken from the announcement, so sender and receivers never disagree about
-   part boundaries even with mismatched `--mtu` settings.
+   registry. The chunk size is taken from the announcement, so sender and
+   receivers never disagree about part boundaries even with mismatched `--mtu`
+   settings.
 3. The sender splits the file into chunk-sized pieces and broadcasts each one
-   as a `TRANSFER` packet, tagged with the session id, at the configured rate.
-4. The sender broadcasts a `FINISH` packet when all chunks have been sent.
+   as a `TRANSFER` packet at the configured rate.
+4. The sender broadcasts `FINISH` when all chunks have been sent.
 5. Each receiver scans for missing chunks and requests them with `RESEND`
    packets.
 6. The sender retransmits each requested chunk.
@@ -39,9 +57,8 @@ part for everyone who missed it.
 
 ## Protocol versioning
 
-The version field in `NEW_PACKET` is checked by receivers: an announcement
-carrying an unknown version is reported and ignored. Announcements from the
-pre-v2 protocol have no version field at all and are shorter than the v2
-fixed header, so they are silently ignored as truncated. The v2 format
-(SHA-256, in-band file name, negotiated chunk size) is not compatible with
-the v1 format used before release v1.0.0.
+A packet carrying the filecast magic with any version other than 3 is dropped,
+and the receiver (or the sender, for RESENDs) prints a single warning naming
+both versions. Packets without the magic — including packets from the
+pre-release v1/v2 formats, which used text markers instead of this header —
+are silently ignored as unrelated traffic.

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -6,11 +6,107 @@
 // makes it testable without spinning up sockets.
 
 #include <cstddef>
+#include <cstdint>
 #include <cctype>
 #include <algorithm>
 #include <string>
 
 namespace Protocol {
+
+// ---- Wire framing (protocol v3) ---------------------------------------------
+//
+// Every packet starts with the same 10-byte header:
+//
+//   magic "FCST"(4) + version(1) + type(1) + session(4)
+//
+// The 4-byte magic keeps stray UDP traffic on our port from being misparsed
+// (and is still recognizable to a human reading a tcpdump hex dump); carrying
+// the version in every packet — not just the announcement — means any future
+// format change degrades into a clear one-line warning instead of silence.
+// The header layout itself is the compatibility contract: future versions keep
+// these 10 bytes so old builds can still say *why* they are ignoring traffic.
+
+constexpr char    MAGIC[4] = {'F', 'C', 'S', 'T'};
+constexpr uint8_t VERSION  = 3;
+
+enum class Type : uint8_t {
+    Announce = 1,  // transfer metadata: file size, chunk size, sha256, name
+    Transfer = 2,  // one chunk of file data
+    Finish   = 3,  // sender has sent every part
+    Resend   = 4,  // receiver asks for a lost part
+};
+
+constexpr size_t HEADER_SIZE = 10;
+// Fixed part of ANNOUNCE, before the variable-length file name:
+// header + file_size(4) + chunk_size(4) + sha256(32) + name_len(2).
+constexpr size_t ANNOUNCE_FIXED = HEADER_SIZE + 42;
+// TRANSFER framing before the payload: header + part(4) + length(4).
+constexpr size_t TRANSFER_HEADER = HEADER_SIZE + 8;
+constexpr size_t FINISH_SIZE = HEADER_SIZE;
+constexpr size_t RESEND_SIZE = HEADER_SIZE + 4;  // header + part(4)
+
+// Big-endian field helpers, self-contained so this header stays socket-free
+// (Utils.hpp drags in the platform socket headers).
+inline void putU16(char* p, uint16_t v) {
+    p[0] = static_cast<char>(v >> 8);
+    p[1] = static_cast<char>(v);
+}
+
+inline void putU32(char* p, uint32_t v) {
+    p[0] = static_cast<char>(v >> 24);
+    p[1] = static_cast<char>(v >> 16);
+    p[2] = static_cast<char>(v >> 8);
+    p[3] = static_cast<char>(v);
+}
+
+inline uint16_t getU16(const char* p) {
+    return static_cast<uint16_t>((static_cast<unsigned char>(p[0]) << 8) |
+                                 static_cast<unsigned char>(p[1]));
+}
+
+inline uint32_t getU32(const char* p) {
+    return (static_cast<uint32_t>(static_cast<unsigned char>(p[0])) << 24) |
+           (static_cast<uint32_t>(static_cast<unsigned char>(p[1])) << 16) |
+           (static_cast<uint32_t>(static_cast<unsigned char>(p[2])) << 8) |
+           static_cast<uint32_t>(static_cast<unsigned char>(p[3]));
+}
+
+struct Header {
+    uint8_t  version = 0;
+    Type     type    = Type::Announce;  // may hold a value outside the enum
+    uint32_t session = 0;
+};
+
+enum class Parse {
+    Ok,          // ours, current version; header filled in
+    NotOurs,     // too short or wrong magic — silently ignore
+    BadVersion,  // our magic, different version — worth a (single) warning
+};
+
+// Write the common header. The caller guarantees buf holds HEADER_SIZE bytes.
+inline void writeHeader(char* buf, Type type, uint32_t session) {
+    buf[0] = MAGIC[0];
+    buf[1] = MAGIC[1];
+    buf[2] = MAGIC[2];
+    buf[3] = MAGIC[3];
+    buf[4] = static_cast<char>(VERSION);
+    buf[5] = static_cast<char>(type);
+    putU32(buf + 6, session);
+}
+
+// Validate the magic/version and extract the header fields. On BadVersion the
+// header is still filled in, so the caller can report which version it saw.
+inline Parse parseHeader(const char* buf, size_t length, Header& h) {
+    if (length < HEADER_SIZE) return Parse::NotOurs;
+    if (buf[0] != MAGIC[0] || buf[1] != MAGIC[1] ||
+        buf[2] != MAGIC[2] || buf[3] != MAGIC[3]) {
+        return Parse::NotOurs;
+    }
+    h.version = static_cast<uint8_t>(buf[4]);
+    h.type    = static_cast<Type>(buf[5]);
+    h.session = getU32(buf + 6);
+    return (h.version == VERSION) ? Parse::Ok : Parse::BadVersion;
+}
 
 // Valid chunk size range (the sender's --mtu bounds). The lower bound also caps
 // the part count, so a forged tiny chunk cannot blow up the receiver.

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -48,25 +48,28 @@ void installSignalHandlers() {
 // only if you know the receiver has enough memory.
 constexpr size_t MAX_FILE_LENGTH = 4ULL * 1024 * 1024 * 1024; // 4 GiB
 
-// Wire protocol the receiver speaks; a NEW_PACKET with any other version is
-// rejected rather than misparsed.
-constexpr uint16_t PROTOCOL_VERSION = 2;
-
-// NEW_PACKET v2 fixed header (see Sender.cpp) and the TRANSFER header size.
-constexpr size_t NEW_PACKET_FIXED = 58;
-constexpr size_t TRANSFER_HEADER  = 20;
-
 // Session the receiver is currently bound to. The sender stamps a random id into
-// every packet; we latch it from the first NEW_PACKET and then reject packets
+// every packet; we latch it from the first ANNOUNCE and then reject packets
 // from any other session, so a second sender (or a restarted one) cannot mix a
 // different file into our buffer and have us report success on garbage.
-size_t session_id   = 0;
-bool   have_session = false;
+uint32_t session_id   = 0;
+bool     have_session = false;
 
-// Chunk size (the sender's MTU) announced in NEW_PACKET. The receiver slices the
+// Chunk size (the sender's MTU) from the ANNOUNCE. The receiver slices the
 // file by this value rather than its own --mtu, so a sender/receiver MTU
 // mismatch no longer live-locks the transfer.
 size_t chunk_size = 0;
+
+// A packet with our magic but a foreign protocol version is dropped; report it
+// once per run so a version-mixed LAN is diagnosable without a warning storm.
+void warnVersionOnce(uint8_t seen) {
+    static bool warned = false;
+    if (warned) return;
+    warned = true;
+    std::cerr << "Warning: ignoring packets with protocol version "
+              << static_cast<int>(seen) << " (this build speaks "
+              << static_cast<int>(Protocol::VERSION) << ")" << std::endl;
+}
 
 // SHA-256 of the whole file, announced by the sender and checked after reassembly.
 uint8_t expected_hash[32] = {0};
@@ -100,15 +103,19 @@ std::vector<size_t> getEmptyParts() {
     return result;
 }
 
-// Validate and store one TRANSFER packet. Returns true when a new part was
-// stored (shared by the main loop and the recovery loop so their validation
-// can never drift apart).
+// Validate and store one TRANSFER packet, parsing it from scratch — the packet
+// may come from the main loop or the recovery loop, and full self-validation
+// keeps the two call sites from ever drifting apart. Returns true when a new
+// part was stored.
 bool handleTransfer(const char* buf, int64_t length) {
-    if (length < static_cast<int64_t>(TRANSFER_HEADER)) return false;
-    if (Utils::getNumberFromBytes(buf + 8, 4) != session_id) return false;
+    Protocol::Header h;
+    if (Protocol::parseHeader(buf, static_cast<size_t>(length), h) != Protocol::Parse::Ok) return false;
+    if (h.type != Protocol::Type::Transfer) return false;
+    if (length < static_cast<int64_t>(Protocol::TRANSFER_HEADER)) return false;
+    if (h.session != session_id) return false;
 
-    size_t part  = Utils::getNumberFromBytes(buf + 12, 4);
-    size_t size  = Utils::getNumberFromBytes(buf + 16, 4);
+    size_t part  = Protocol::getU32(buf + Protocol::HEADER_SIZE);
+    size_t size  = Protocol::getU32(buf + Protocol::HEADER_SIZE + 4);
     size_t total = totalParts();
     if (part >= total) return false;
     if (parts.find(part) != parts.end()) return false;
@@ -117,10 +124,10 @@ bool handleTransfer(const char* buf, int64_t length) {
     // must equal the remaining bytes. Anything else is malformed and would
     // either silently zero-pad data or write past the file buffer.
     if (size != Protocol::expectedPartSize(part, file_length, chunk_size)) return false;
-    if (static_cast<size_t>(length) < size + TRANSFER_HEADER) return false;
+    if (static_cast<size_t>(length) < size + Protocol::TRANSFER_HEADER) return false;
 
     parts.insert(part);
-    memcpy(file + part * chunk_size, buf + TRANSFER_HEADER, size);
+    memcpy(file + part * chunk_size, buf + Protocol::TRANSFER_HEADER, size);
     received_bytes += size;
     reporter.update(received_bytes);
     if (verbose) std::cout << "Receive " << part << " part with size " << size << std::endl;
@@ -484,7 +491,7 @@ int verifyAndWrite() {
  */
 // Returns a process exit code: 0 on success, non-zero on failure.
 int checkParts() {
-    size_t bufcap = std::max(chunk_size + TRANSFER_HEADER, static_cast<size_t>(2048));
+    size_t bufcap = std::max(chunk_size + Protocol::TRANSFER_HEADER, static_cast<size_t>(2048));
     char* buffer = new (std::nothrow) char[bufcap];
     if (!buffer) {
         std::cerr << "Error: Can't allocate receive buffer" << std::endl;
@@ -498,10 +505,10 @@ int checkParts() {
     while (ttl && !emptyParts.empty()) {
         if (g_interrupted) return onInterrupt(buffer);
         for (auto index : emptyParts) {
-            snprintf(buffer, 7, "RESEND");
-            Utils::writeBytesFromNumber(buffer +  6, session_id, 4);
-            Utils::writeBytesFromNumber(buffer + 10, index,      4);
-            sendto(_socket, buffer, 14, 0, reinterpret_cast<sockaddr*>(&broadcast_address),
+            Protocol::writeHeader(buffer, Protocol::Type::Resend, session_id);
+            Protocol::putU32(buffer + Protocol::HEADER_SIZE, static_cast<uint32_t>(index));
+            sendto(_socket, buffer, static_cast<int>(Protocol::RESEND_SIZE), 0,
+                   reinterpret_cast<sockaddr*>(&broadcast_address),
                    sizeof(broadcast_address));
             if (verbose) std::cout << "Request part of file with index " << index << std::endl;
             if (pace_us > 0) std::this_thread::sleep_for(std::chrono::microseconds(pace_us));
@@ -521,8 +528,17 @@ int checkParts() {
             auto length = recvfrom(_socket, buffer, static_cast<int>(bufcap), 0,
                                    reinterpret_cast<sockaddr*>(&sender_address),
                                    &sender_address_length);
-            if (length <= 0) break;                              // queue drained this round
-            if (strncmp(buffer, "TRANSFER", 8) != 0) continue;   // e.g. our own RESEND
+            if (length <= 0) break;  // queue drained this round
+            // A foreign protocol version deserves its one warning even when it
+            // first shows up during recovery; everything else that is not a
+            // TRANSFER for our session (e.g. our own looped-back RESENDs) is
+            // rejected by handleTransfer's own validation.
+            Protocol::Header h;
+            if (Protocol::parseHeader(buffer, static_cast<size_t>(length), h) ==
+                Protocol::Parse::BadVersion) {
+                warnVersionOnce(h.version);
+                continue;
+            }
             if (handleTransfer(buffer, static_cast<int64_t>(length))) progressed = true;
         }
 
@@ -569,7 +585,7 @@ bool announceValid(size_t announced, size_t chunk, int& exit_code) {
 
 // Grow the receive buffer so it can hold a full chunk for this transfer.
 bool growRecvBuffer(char*& buf, size_t& bufcap, int& exit_code) {
-    size_t need = chunk_size + TRANSFER_HEADER;
+    size_t need = chunk_size + Protocol::TRANSFER_HEADER;
     if (need > bufcap) {
         delete[] buf;
         bufcap = need;
@@ -607,28 +623,25 @@ bool prepareStorage(char*& buf, size_t& bufcap, size_t announced, size_t chunk,
     return true;
 }
 
-// Parse and latch a NEW_PACKET. Sets exit_code and returns false if the caller
-// should return that code; returns true to continue the receive loop. buf may be
-// reallocated to fit the announced chunk size.
-bool handleNewPacket(char*& buf, size_t& bufcap, int64_t length, int& exit_code) {
-    if (length < static_cast<int64_t>(NEW_PACKET_FIXED)) return true;  // too short, ignore
-    if (Utils::getNumberFromBytes(buf + 10, 2) != PROTOCOL_VERSION) {
-        std::cerr << "Warning: ignoring NEW_PACKET with unsupported protocol version" << std::endl;
-        return true;
-    }
+// Parse and latch an ANNOUNCE (the session id comes pre-parsed from the common
+// header). Sets exit_code and returns false if the caller should return that
+// code; returns true to continue the receive loop. buf may be reallocated to
+// fit the announced chunk size.
+bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incoming_sid,
+                    int& exit_code) {
+    if (length < static_cast<int64_t>(Protocol::ANNOUNCE_FIXED)) return true;  // too short, ignore
 
-    size_t incoming_sid = Utils::getNumberFromBytes(buf + 12, 4);
-    // A NEW_PACKET from a different session (a second sender, or our own sender
+    // An ANNOUNCE from a different session (a second sender, or our own sender
     // restarted) must not clobber the transfer already in progress.
     if (have_session && incoming_sid != session_id) {
-        std::cerr << "Warning: ignoring NEW_PACKET from another sender session" << std::endl;
+        std::cerr << "Warning: ignoring announcement from another sender session" << std::endl;
         return true;
     }
 
-    size_t announced   = Utils::getNumberFromBytes(buf + 16, 4);
-    size_t incoming_cs = Utils::getNumberFromBytes(buf + 20, 4);
-    size_t name_len    = Utils::getNumberFromBytes(buf + 56, 2);
-    if (static_cast<size_t>(length) < NEW_PACKET_FIXED + name_len) return true;  // truncated
+    size_t announced   = Protocol::getU32(buf + Protocol::HEADER_SIZE);
+    size_t incoming_cs = Protocol::getU32(buf + Protocol::HEADER_SIZE + 4);
+    size_t name_len    = Protocol::getU16(buf + Protocol::HEADER_SIZE + 40);
+    if (static_cast<size_t>(length) < Protocol::ANNOUNCE_FIXED + name_len) return true;  // truncated
 
     // Only a recognised packet from our sender refreshes ttl. Unrecognised
     // traffic (stray broadcasts, other receivers' RESENDs, garbage) deliberately
@@ -638,15 +651,15 @@ bool handleNewPacket(char*& buf, size_t& bufcap, int64_t length, int& exit_code)
 
     if (!announceValid(announced, incoming_cs, exit_code)) return false;
 
-    // Duplicate retransmission of the same NEW_PACKET: keep accumulated parts.
+    // Duplicate retransmission of the same ANNOUNCE: keep accumulated parts.
     if (file != nullptr && announced == file_length && incoming_cs == chunk_size) return true;
 
     session_id   = incoming_sid;
     have_session = true;
     file_length  = announced;
     chunk_size   = incoming_cs;
-    memcpy(expected_hash, buf + 24, 32);
-    announced_name = Protocol::sanitizeName(std::string(buf + NEW_PACKET_FIXED, name_len));
+    memcpy(expected_hash, buf + Protocol::HEADER_SIZE + 8, 32);
+    announced_name = Protocol::sanitizeName(std::string(buf + Protocol::ANNOUNCE_FIXED, name_len));
     if (!fileNameFromCli) fileName = announced_name;
 
     bool resumed = false;
@@ -668,9 +681,11 @@ bool handleNewPacket(char*& buf, size_t& bufcap, int64_t length, int& exit_code)
 
 
 // Latch the "sender finished" state from a FINISH packet for our session.
-void handleFinish(const char* buf, int64_t length, bool& finish) {
-    if (length < 10) return;
-    if (Utils::getNumberFromBytes(buf + 6, 4) != session_id) return;
+// The have_session gate matters: session_id starts at 0, so without it a forged
+// FINISH with session 0 would terminate any receiver still waiting for its
+// ANNOUNCE (a one-packet unauthenticated DoS).
+void handleFinish(uint32_t incoming_sid, bool& finish) {
+    if (!have_session || incoming_sid != session_id) return;
     ttl = ttl_max;
     if (!finish) {
         if (verbose) std::cout << "Server finished transferring" << std::endl;
@@ -682,13 +697,31 @@ void handleFinish(const char* buf, int64_t length, bool& finish) {
 // receiving; any value >= 0 is a process exit code the caller should return
 // after freeing its buffers. buf may be reallocated to fit the announced chunk.
 int dispatchPacket(char*& buf, size_t& bufcap, int64_t length, bool& finish) {
-    if (strncmp(buf, "NEW_PACKET", 10) == 0) {
-        int exit_code = 0;
-        if (!handleNewPacket(buf, bufcap, length, exit_code)) return exit_code;
-    } else if (strncmp(buf, "TRANSFER", 8) == 0 && file != nullptr) {
-        if (handleTransfer(buf, length)) ttl = ttl_max;
-    } else if (strncmp(buf, "FINISH", 6) == 0) {
-        handleFinish(buf, length, finish);
+    Protocol::Header h;
+    switch (Protocol::parseHeader(buf, static_cast<size_t>(length), h)) {
+        case Protocol::Parse::NotOurs:
+            return -1;  // stray traffic on our port — not even worth a warning
+        case Protocol::Parse::BadVersion:
+            warnVersionOnce(h.version);
+            return -1;
+        case Protocol::Parse::Ok:
+            break;
+    }
+
+    switch (h.type) {
+        case Protocol::Type::Announce: {
+            int exit_code = 0;
+            if (!handleAnnounce(buf, bufcap, length, h.session, exit_code)) return exit_code;
+            break;
+        }
+        case Protocol::Type::Transfer:
+            if (file != nullptr && handleTransfer(buf, length)) ttl = ttl_max;
+            break;
+        case Protocol::Type::Finish:
+            handleFinish(h.session, finish);
+            break;
+        default:
+            break;  // other receivers' RESENDs, or an unknown type: ignore
     }
     return -1;
 }
@@ -712,13 +745,13 @@ int run() {
     while (ttl > 0) {
         if (g_interrupted) return onInterrupt(buffer);
         // Sender finished transferring — move to the recovery phase (or bail if
-        // we joined too late to ever have received NEW_PACKET).
+        // we joined too late to ever have received the ANNOUNCE).
         if (finish) {
             if (file != nullptr) {
                 delete[] buffer;
                 return checkParts();
             }
-            std::cerr << "Error: Received FINISH without NEW_PACKET — joined too late" << std::endl;
+            std::cerr << "Error: Received FINISH without an ANNOUNCE — joined too late" << std::endl;
             delete[] buffer;
             return 2;
         }

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -2,6 +2,7 @@
 #include "Config.hpp"
 #include "Sha256.hpp"
 #include "Progress.hpp"
+#include "Protocol.hpp"
 
 #include <iostream>
 #include <fstream>
@@ -20,26 +21,14 @@ using namespace std::chrono_literals;
 
 namespace Sender {
 
-// TRANSFER header: "TRANSFER"(8) + session id(4) + part number(4) + length(4).
-constexpr int HEADER_SIZE = 20;
-
-// Wire protocol version, announced in NEW_PACKET so a receiver can reject a
-// sender it does not understand instead of misparsing the stream.
-constexpr uint16_t PROTOCOL_VERSION = 2;
-
-// NEW_PACKET v2 fixed header, before the variable-length file name:
-// "NEW_PACKET"(10) + version(2) + session(4) + file_length(4) + chunk_size(4)
-// + sha256(32) + name_len(2) = 58 bytes.
-constexpr int NEW_PACKET_FIXED = 58;
-
 // Random per-transfer id, generated in run() and stamped into every packet so a
 // receiver can reject packets from a different sender (a second concurrent
 // sender, or a restart) instead of silently mixing two files into one buffer.
 uint32_t session_id = 0;
 
-// The file size is announced in a 4-byte field in NEW_PACKET, so anything that
-// does not fit into 32 bits would be silently truncated on the wire (a 4 GiB
-// file would be announced as 0). Reject such files up front instead.
+// The file size travels in a 4-byte ANNOUNCE field, so anything that does not
+// fit into 32 bits would be silently truncated on the wire (a 4 GiB file would
+// be announced as 0). Reject such files up front instead.
 constexpr size_t MAX_WIRE_FILE_LENGTH = 0xFFFFFFFFULL;
 
 // Strip any directory part; only the base name travels on the wire so the
@@ -61,13 +50,12 @@ void sendPart(size_t part_index) {
     size_t packet_length = file_length - offset;
     if (packet_length > static_cast<size_t>(mtu)) packet_length = static_cast<size_t>(mtu);
 
-    snprintf(buffer, 9, "TRANSFER");
-    Utils::writeBytesFromNumber(buffer +  8, session_id,    4); // Write section "session"
-    Utils::writeBytesFromNumber(buffer + 12, part_index,    4); // Write section "number"
-    Utils::writeBytesFromNumber(buffer + 16, packet_length, 4); // Write section "length"
-    memcpy(buffer + 20, file + offset, packet_length);          // Write section "data"
+    Protocol::writeHeader(buffer, Protocol::Type::Transfer, session_id);
+    Protocol::putU32(buffer + Protocol::HEADER_SIZE,     static_cast<uint32_t>(part_index));
+    Protocol::putU32(buffer + Protocol::HEADER_SIZE + 4, static_cast<uint32_t>(packet_length));
+    memcpy(buffer + Protocol::TRANSFER_HEADER, file + offset, packet_length);
 
-    auto sent = sendto(_socket, buffer, static_cast<int>(packet_length + HEADER_SIZE), 0,
+    auto sent = sendto(_socket, buffer, static_cast<int>(packet_length + Protocol::TRANSFER_HEADER), 0,
                        reinterpret_cast<sockaddr*>(&broadcast_address), sizeof(broadcast_address));
     if (sent < 0) {
         std::cerr << "Warning: Failed to send part " << part_index << std::endl;
@@ -84,9 +72,8 @@ void pace() {
 }
 
 void sendFinish() {
-    snprintf(buffer, 7, "FINISH");
-    Utils::writeBytesFromNumber(buffer + 6, session_id, 4);
-    if (sendto(_socket, buffer, 10, 0,
+    Protocol::writeHeader(buffer, Protocol::Type::Finish, session_id);
+    if (sendto(_socket, buffer, static_cast<int>(Protocol::FINISH_SIZE), 0,
                reinterpret_cast<sockaddr*>(&broadcast_address),
                sizeof(broadcast_address)) < 0) {
         std::cerr << "Warning: Failed to send FINISH" << std::endl;
@@ -137,9 +124,9 @@ int loadFileIntoMemory() {
     return 0;
 }
 
-// Build and broadcast NEW_PACKET (retransmitted a few times, since a single
+// Build and broadcast the ANNOUNCE (retransmitted a few times, since a single
 // drop would strand every receiver and there is no RESEND for it).
-void sendNewPacket() {
+void sendAnnounce() {
     std::random_device rd;
     session_id = static_cast<uint32_t>(rd());
 
@@ -149,28 +136,26 @@ void sendNewPacket() {
     if (verbose) std::cout << "Ok: sha256 " << Sha256::hex(file_hash) << std::endl;
 
     // Name the receiver saves under unless it was given an explicit output path.
-    // Clamp so the whole NEW_PACKET fits the send buffer (2 * mtu) and the length
+    // Clamp so the whole ANNOUNCE fits the send buffer (2 * mtu) and the length
     // field (a byte count well under 2^16).
     std::string name = baseName(fileName);
-    size_t max_name = static_cast<size_t>(2 * mtu) - NEW_PACKET_FIXED;
+    size_t max_name = static_cast<size_t>(2 * mtu) - Protocol::ANNOUNCE_FIXED;
     if (max_name > 255) max_name = 255;
     if (name.size() > max_name) name.resize(max_name);
 
-    snprintf(buffer, 11, "NEW_PACKET");
-    Utils::writeBytesFromNumber(buffer + 10, PROTOCOL_VERSION,          2);
-    Utils::writeBytesFromNumber(buffer + 12, session_id,               4);
-    Utils::writeBytesFromNumber(buffer + 16, file_length,              4);
-    Utils::writeBytesFromNumber(buffer + 20, static_cast<size_t>(mtu), 4);
-    memcpy(buffer + 24, file_hash, 32);
-    Utils::writeBytesFromNumber(buffer + 56, name.size(),              2);
-    memcpy(buffer + NEW_PACKET_FIXED, name.data(), name.size());
-    int new_packet_len = NEW_PACKET_FIXED + static_cast<int>(name.size());
+    Protocol::writeHeader(buffer, Protocol::Type::Announce, session_id);
+    Protocol::putU32(buffer + Protocol::HEADER_SIZE,     static_cast<uint32_t>(file_length));
+    Protocol::putU32(buffer + Protocol::HEADER_SIZE + 4, static_cast<uint32_t>(mtu));
+    memcpy(buffer + Protocol::HEADER_SIZE + 8, file_hash, 32);
+    Protocol::putU16(buffer + Protocol::HEADER_SIZE + 40, static_cast<uint16_t>(name.size()));
+    memcpy(buffer + Protocol::ANNOUNCE_FIXED, name.data(), name.size());
+    int announce_len = static_cast<int>(Protocol::ANNOUNCE_FIXED + name.size());
 
     for (int i = 0; i < 3; ++i) {
-        if (sendto(_socket, buffer, new_packet_len, 0,
+        if (sendto(_socket, buffer, announce_len, 0,
                    reinterpret_cast<sockaddr*>(&broadcast_address),
                    sizeof(broadcast_address)) < 0) {
-            std::cerr << "Warning: Failed to send NEW_PACKET" << std::endl;
+            std::cerr << "Warning: Failed to send ANNOUNCE" << std::endl;
         }
         if (i + 1 < 3) pace();
     }
@@ -205,12 +190,26 @@ size_t serveResends(size_t total_parts) {
             continue;
         }
 
-        if (strncmp(buffer, "RESEND", 6) != 0) continue;
-        // Ignore RESENDs shorter than the header or belonging to a different
-        // session (another sender's receivers requesting their own transfer).
-        if (result < 14) continue;
-        if (Utils::getNumberFromBytes(buffer + 6, 4) != session_id) continue;
-        size_t part = Utils::getNumberFromBytes(buffer + 10, 4);
+        // The socket hears our own TRANSFER/FINISH broadcasts too; only RESENDs
+        // for our session and current protocol version matter here. A foreign
+        // version is reported once — it explains "why is nothing recovering".
+        Protocol::Header h;
+        Protocol::Parse parsed = Protocol::parseHeader(buffer, static_cast<size_t>(result), h);
+        if (parsed == Protocol::Parse::BadVersion) {
+            static bool warned = false;
+            if (!warned) {
+                warned = true;
+                std::cerr << "Warning: ignoring packets with protocol version "
+                          << static_cast<int>(h.version) << " (this build speaks "
+                          << static_cast<int>(Protocol::VERSION) << ")" << std::endl;
+            }
+            continue;
+        }
+        if (parsed != Protocol::Parse::Ok) continue;
+        if (h.type != Protocol::Type::Resend) continue;
+        if (static_cast<size_t>(result) < Protocol::RESEND_SIZE) continue;
+        if (h.session != session_id) continue;
+        size_t part = Protocol::getU32(buffer + Protocol::HEADER_SIZE);
         if (part >= total_parts) continue;
 
         auto epoch    = std::chrono::system_clock::now().time_since_epoch();
@@ -248,7 +247,7 @@ int run() {
     }
     if (verbose) std::cout << "Ok: File successfully copied to RAM" << std::endl;
 
-    sendNewPacket();
+    sendAnnounce();
 
     const std::string name = baseName(fileName);
     Progress::Reporter reporter;

--- a/src/Sha256.hpp
+++ b/src/Sha256.hpp
@@ -3,7 +3,7 @@
 
 // Small self-contained SHA-256 (public-domain algorithm, FIPS 180-4). Used to
 // verify the integrity of a received file against the digest the sender puts in
-// NEW_PACKET. Header-only so it stays dependency-free like the rest of filecast.
+// the ANNOUNCE. Header-only so it stays dependency-free like the rest of filecast.
 
 #include <cstdint>
 #include <cstddef>

--- a/tests/Tests.cpp
+++ b/tests/Tests.cpp
@@ -65,6 +65,77 @@ TEST(Sha256, DetectsSingleBitFlip) {
     EXPECT_NE(sha256Hex(a), sha256Hex(b));
 }
 
+// --- Wire framing (common header) -------------------------------------------
+
+TEST(Protocol, HeaderRoundTrip) {
+    char buf[Protocol::HEADER_SIZE];
+    Protocol::writeHeader(buf, Protocol::Type::Transfer, 0xDEADBEEFu);
+    EXPECT_EQ(memcmp(buf, "FCST", 4), 0);
+
+    Protocol::Header h;
+    EXPECT_EQ(Protocol::parseHeader(buf, sizeof(buf), h), Protocol::Parse::Ok);
+    EXPECT_EQ(h.version, Protocol::VERSION);
+    EXPECT_EQ(h.type, Protocol::Type::Transfer);
+    EXPECT_EQ(h.session, 0xDEADBEEFu);
+}
+
+TEST(Protocol, HeaderRejectsShortAndForeign) {
+    char buf[Protocol::HEADER_SIZE];
+    Protocol::writeHeader(buf, Protocol::Type::Finish, 42);
+
+    Protocol::Header h;
+    // Truncated: even one byte short of the header is not ours.
+    EXPECT_EQ(Protocol::parseHeader(buf, Protocol::HEADER_SIZE - 1, h), Protocol::Parse::NotOurs);
+    EXPECT_EQ(Protocol::parseHeader(buf, 0, h), Protocol::Parse::NotOurs);
+
+    // Wrong magic: stray traffic (including the old text-tagged v2 packets)
+    // must be silently ignored, not misparsed.
+    char stray[16] = {0};
+    memcpy(stray, "NEW_PACKET", 10);
+    EXPECT_EQ(Protocol::parseHeader(stray, sizeof(stray), h), Protocol::Parse::NotOurs);
+}
+
+TEST(Protocol, HeaderAcceptsUnknownType) {
+    // Forward compatibility contract: an unknown type byte within the current
+    // version parses Ok — the dispatcher ignores it — rather than being
+    // mistaken for foreign traffic.
+    char buf[Protocol::HEADER_SIZE];
+    Protocol::writeHeader(buf, static_cast<Protocol::Type>(200), 99);
+
+    Protocol::Header h;
+    EXPECT_EQ(Protocol::parseHeader(buf, sizeof(buf), h), Protocol::Parse::Ok);
+    EXPECT_EQ(static_cast<uint8_t>(h.type), 200);
+    EXPECT_EQ(h.session, 99u);
+}
+
+TEST(Protocol, HeaderReportsForeignVersion) {
+    char buf[Protocol::HEADER_SIZE];
+    Protocol::writeHeader(buf, Protocol::Type::Announce, 7);
+    buf[4] = static_cast<char>(Protocol::VERSION + 1);
+
+    Protocol::Header h;
+    EXPECT_EQ(Protocol::parseHeader(buf, sizeof(buf), h), Protocol::Parse::BadVersion);
+    // The header is still filled in so the caller can say which version it saw.
+    EXPECT_EQ(h.version, Protocol::VERSION + 1);
+    EXPECT_EQ(h.session, 7u);
+}
+
+TEST(Protocol, FieldHelpersRoundTrip) {
+    char buf[4];
+    for (uint32_t v : {0u, 1u, 0xFFu, 0x1234u, 0xFFFFu, 0x12345678u, 0xFFFFFFFFu}) {
+        Protocol::putU32(buf, v);
+        EXPECT_EQ(Protocol::getU32(buf), v);
+    }
+    for (uint16_t v : {uint16_t{0}, uint16_t{1}, uint16_t{0x1234}, uint16_t{0xFFFF}}) {
+        Protocol::putU16(buf, v);
+        EXPECT_EQ(Protocol::getU16(buf), v);
+    }
+    // Big-endian on the wire: most significant byte first.
+    Protocol::putU32(buf, 0x0A0B0C0Du);
+    EXPECT_EQ(buf[0], 0x0A);
+    EXPECT_EQ(buf[3], 0x0D);
+}
+
 // --- Protocol helpers -------------------------------------------------------
 
 TEST(Protocol, SanitizeNameStripsDirectories) {

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -170,6 +170,41 @@ run_iface_validation() {
 }
 run_iface_validation
 
+# Announced-name delivery: run `receive` with NO output path, so the file must
+# be saved under the name carried in the ANNOUNCE. This is the only test that
+# exercises the name_len/name wire fields — every other case passes an explicit
+# output path, which discards the announced name.
+run_announced_name_test() {
+    local dir="$WORKDIR/announced-name"
+    mkdir -p "$dir/send" "$dir/recv"
+    dd if=/dev/urandom of="$dir/send/announced-name.bin" bs=1024 count=50 status=none
+
+    echo "==> [name] starting receiver with no output path"
+    ( cd "$dir/recv" && exec "$BINARY" receive --to 127.0.0.1 \
+          --bind-port 33409 --port 33410 --ttl 5 --delay-ms 0 > recv.log 2>&1 ) &
+    local rpid=$!
+    sleep 1
+    "$BINARY" send "$dir/send/announced-name.bin" --to 127.0.0.1 \
+              --bind-port 33410 --port 33409 --ttl 2 --delay-ms 0 \
+              > "$dir/send.log" 2>&1
+    if ! wait "$rpid"; then
+        echo "FAIL: [name] receiver exited non-zero"
+        cat "$dir/recv/recv.log"
+        return 1
+    fi
+    if [ ! -f "$dir/recv/announced-name.bin" ]; then
+        echo "FAIL: [name] file was not saved under the announced name"
+        ls "$dir/recv"; tail -5 "$dir/recv/recv.log"
+        return 1
+    fi
+    if ! cmp -s "$dir/send/announced-name.bin" "$dir/recv/announced-name.bin"; then
+        echo "FAIL: [name] file saved under the announced name does not match source"
+        return 1
+    fi
+    echo "PASS: [name] file delivered under its announced name"
+}
+run_announced_name_test
+
 # Resume: interrupt a slow receive with SIGINT, then finish it with --resume.
 # Timing-based, so if no snapshot lands (transfer finished or nothing arrived in
 # the window) it SKIPs; but once a snapshot exists, resume must succeed or FAIL.


### PR DESCRIPTION
Replaces the v2 text-tagged packets — `"NEW_PACKET"`, `"TRANSFER"`, `"FINISH"`, `"RESEND"` with per-type field offsets — with one uniform header on **every** packet:

```
magic "FCST"(4) + version(1)=3 + type(1) + session(4)   = 10 bytes
```

### Why
- **One parser, one set of offsets.** The old design put `session` at +10/+8/+6 depending on packet type — exactly the off-by-one breeding ground the audit kept finding bugs in. Now a single `parseHeader` validates magic/version/type/session for all four types.
- **Version in every packet.** Previously only the announcement carried a version, so a v3 receiver hearing a v2 mid-stream just sat at "waiting forever". Now any filecast packet with a foreign version is reported **once** (by both receiver and sender) and ignored.
- **Forward-compat contract.** The 10-byte header is stable; an unknown *type* byte within the current version parses `Ok` and is ignored, so a future v3.x packet type won't be mistaken for foreign traffic.

Framing helpers (`putU16/putU32/getU16/getU32`, `writeHeader/parseHeader`, `Header`/`Parse`) live in `Protocol.hpp` — socket-free and unit-tested. `NEW_PACKET` is renamed **ANNOUNCE** throughout (it was always an announcement).

### Wire format (v3)
| Packet | Body after the common header |
| --- | --- |
| ANNOUNCE | file_size(4) · chunk(4) · sha256(32) · name_len(2) · name |
| TRANSFER | part(4) · length(4) · data |
| FINISH | — |
| RESEND | part(4) |

Verified on the wire with a UDP sniffer — every packet starts `46 43 53 54 03` (`FCST` + v3).

### Breaking change
This **breaks** wire compat with the pre-release v1/v2 formats. Deliberate, and done now while there are zero real users — so that encryption later is the *only* remaining protocol break. **Consequence:** the published v1.0.0 assets speak v2; after this merges we delete and re-cut v1.0.0 from master (the release workflow already rebuilds all four binaries + checksums).

### Adversarial review (5 reviewers + 2 skeptics/finding) — 2 confirmed, fixed:
1. **Forged FINISH DoS** (medium): a spoofed 10-byte `FINISH` with session `0` could terminate a receiver still waiting for its ANNOUNCE — `handleFinish` gated only on session equality, and `session_id` starts at 0. Now gated on `have_session`. **Verified live**: the spoofed FINISH is ignored and the receiver still completes the transfer (bytes identical, sha256 verified). *(Pre-existing since v2 — the redesign was the moment to close it.)*
2. **Recovery-phase version warning** (low): a foreign version first seen during the RESEND drain loop now also warns once.

Plus test hardening the review surfaced: the announced file **name** wire fields were never exercised (every e2e case passed an explicit output path). Added an e2e case that receives with no output path and asserts the file lands under its announced name, and a forward-compat unit test for unknown type bytes.

Local: unit + e2e + e2e_lossy green; ASan/UBSan green; lizard CCN ≤ 14; shellcheck clean.