### PR TITLE
Use the lowercase gistrec/filecast repo name in links and install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ One sender, any number of receivers, no internet required.
 <p>
     <a href="https://github.com/gistrec/filecast/actions/workflows/tests.yml">
         <img src="https://github.com/gistrec/filecast/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
-    <a href="https://app.codacy.com/gh/gistrec/Filecast/dashboard">
+    <a href="https://app.codacy.com/gh/gistrec/filecast/dashboard">
         <img src="https://img.shields.io/codacy/grade/4c8169bcab3a4df18baad4e5658ec8ce" alt="Code quality"></a>
     <a href="https://github.com/gistrec/filecast/releases">
         <img src="https://img.shields.io/github/v/release/gistrec/filecast" alt="Release"></a>
@@ -74,7 +74,7 @@ filecast send photo.jpg --to 192.168.1.50
 **One-liner** (Linux, macOS):
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/gistrec/Filecast/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/gistrec/filecast/master/install.sh | sh
 ```
 
 The script picks the prebuilt binary for your platform from the latest
@@ -84,7 +84,7 @@ SHA-256 against the release's `checksums.txt`, and installs it to
 you own:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/gistrec/Filecast/master/install.sh | BIN_DIR="$HOME/bin" sh
+curl -fsSL https://raw.githubusercontent.com/gistrec/filecast/master/install.sh | BIN_DIR="$HOME/bin" sh
 ```
 
 **Manual**: download a binary from the

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -7,7 +7,7 @@ many LAN machines with the least setup?**
 
 Facts were checked against each project's own documentation and source in
 July 2026 — versions and features move, so if you spot an error please
-[open an issue](https://github.com/gistrec/Filecast/issues).
+[open an issue](https://github.com/gistrec/filecast/issues).
 
 |  | filecast | [udpcast](https://www.udpcast.linux.lu/) | [UFTP](https://uftp-multicast.sourceforge.net/) | [croc](https://github.com/schollz/croc) | [LocalSend](https://localsend.org/) | [magic-wormhole](https://github.com/magic-wormhole/magic-wormhole) |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # GitHub Releases, verifies its SHA-256 against the release's checksums.txt,
 # and installs it as `filecast`.
 #
-#   curl -fsSL https://raw.githubusercontent.com/gistrec/Filecast/master/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/gistrec/filecast/master/install.sh | sh
 #
 # Options (flags or environment variables):
 #   --version vX.Y.Z   / FILECAST_VERSION   install a specific release (default: latest)
@@ -13,7 +13,7 @@
 # partially downloaded script fails to parse instead of running half-way.
 set -eu
 
-REPO="gistrec/Filecast"
+REPO="gistrec/filecast"
 # Overridable base URL so the script can be tested against a local mock server.
 DOWNLOAD_BASE="${FILECAST_DOWNLOAD_BASE:-https://github.com/${REPO}/releases}"
 


### PR DESCRIPTION
Follow-up to the `Filecast` → `filecast` repository rename (matches the binary name, the brand, and the convention of most CLI tools).

GitHub is case-insensitive and sets up a redirect, so nothing was broken by the rename — but the six hardcoded `gistrec/Filecast` URLs should use the canonical lowercase name:

- README: Codacy dashboard link + the two `curl | sh` install one-liners
- `install.sh`: the `REPO` variable and the header comment's example command
- `docs/COMPARISON.md`: the "open an issue" link

No functional change; `shellcheck -s sh install.sh` clean. The install one-liner keeps working throughout (case-insensitive raw URL); this just makes the canonical name consistent before the launch.