### PR TITLE
Document the Homebrew tap and link the encryption issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ One sender, any number of receivers, no internet required.
 <p>
     <a href="https://github.com/gistrec/filecast/actions/workflows/tests.yml">
         <img src="https://github.com/gistrec/filecast/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
-    <a href="https://app.codacy.com/gh/gistrec/Filecast/dashboard">
+    <a href="https://app.codacy.com/gh/gistrec/filecast/dashboard">
         <img src="https://img.shields.io/codacy/grade/4c8169bcab3a4df18baad4e5658ec8ce" alt="Code quality"></a>
     <a href="https://github.com/gistrec/filecast/releases">
         <img src="https://img.shields.io/github/v/release/gistrec/filecast" alt="Release"></a>
@@ -74,7 +74,7 @@ filecast send photo.jpg --to 192.168.1.50
 **One-liner** (Linux, macOS):
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/gistrec/Filecast/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/gistrec/filecast/master/install.sh | sh
 ```
 
 The script picks the prebuilt binary for your platform from the latest
@@ -84,7 +84,7 @@ SHA-256 against the release's `checksums.txt`, and installs it to
 you own:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/gistrec/Filecast/master/install.sh | BIN_DIR="$HOME/bin" sh
+curl -fsSL https://raw.githubusercontent.com/gistrec/filecast/master/install.sh | BIN_DIR="$HOME/bin" sh
 ```
 
 **Manual**: download a binary from the

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ filecast send photo.jpg --to 192.168.1.50
 
 ## Installation
 
+**Homebrew** (macOS, Linux):
+
+```sh
+brew install gistrec/filecast/filecast
+```
+
 **One-liner** (Linux, macOS):
 
 ```sh

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -17,7 +17,7 @@ July 2026 — versions and features move, so if you spot an error please
 | Zero receiver setup (one binary, one command) | ✅ | ✅ | ❌ per-receiver daemon [^uftp-daemon] | ✅ | ⚠️ GUI app install | ⚠️ pip or distro package |
 | Resume an interrupted transfer | ✅ `--resume` | ❌ [^udpcast-streaming] | ⚠️ session restart [^uftp-restart] | ✅ | ❌ open feature request since 2023 | ❌ open feature request since 2016 |
 | End-to-end file integrity check | ✅ SHA-256 [^filecast-hash] | ❌ [^udpcast-integrity] | ⚠️ [^uftp-integrity] | ✅ [^croc-hash] | ✅ (TLS transport) | ✅ (encrypted transport) |
-| Encryption | ❌ not yet | ❌ [^udpcast-pipe] | ✅ default since v5.0 [^uftp-crypto] | ✅ end-to-end (PAKE) | ✅ HTTPS by default [^localsend-tls] | ✅ end-to-end (PAKE) |
+| Encryption | ❌ [not yet](https://github.com/gistrec/filecast/issues/22) | ❌ [^udpcast-pipe] | ✅ default since v5.0 [^uftp-crypto] | ✅ end-to-end (PAKE) | ✅ HTTPS by default [^localsend-tls] | ✅ end-to-end (PAKE) |
 | Interface | CLI | CLI | CLI (daemon) | CLI | GUI [^localsend-cli] | CLI |
 | License | MIT | GPL-2.0 | GPL-3.0 [^uftp-license] | MIT | Apache-2.0 | MIT |
 | Latest release when checked (2026-07) | v1.0.0 (2026-07) | 2025-02 | 2023-12 | 2026-07 | 2025-02 [^localsend-activity] | 2026-05 |

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -7,7 +7,7 @@ many LAN machines with the least setup?**
 
 Facts were checked against each project's own documentation and source in
 July 2026 — versions and features move, so if you spot an error please
-[open an issue](https://github.com/gistrec/Filecast/issues).
+[open an issue](https://github.com/gistrec/filecast/issues).
 
 |  | filecast | [udpcast](https://www.udpcast.linux.lu/) | [UFTP](https://uftp-multicast.sourceforge.net/) | [croc](https://github.com/schollz/croc) | [LocalSend](https://localsend.org/) | [magic-wormhole](https://github.com/magic-wormhole/magic-wormhole) |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # GitHub Releases, verifies its SHA-256 against the release's checksums.txt,
 # and installs it as `filecast`.
 #
-#   curl -fsSL https://raw.githubusercontent.com/gistrec/Filecast/master/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/gistrec/filecast/master/install.sh | sh
 #
 # Options (flags or environment variables):
 #   --version vX.Y.Z   / FILECAST_VERSION   install a specific release (default: latest)
@@ -13,7 +13,7 @@
 # partially downloaded script fails to parse instead of running half-way.
 set -eu
 
-REPO="gistrec/Filecast"
+REPO="gistrec/filecast"
 # Overridable base URL so the script can be tested against a local mock server.
 DOWNLOAD_BASE="${FILECAST_DOWNLOAD_BASE:-https://github.com/${REPO}/releases}"
 


### PR DESCRIPTION
Small docs follow-up to the packaging work.

- **README**: adds `brew install gistrec/filecast/filecast` to Installation. The tap ([gistrec/homebrew-filecast](https://github.com/gistrec/homebrew-filecast)) is live — the formula passes `brew style` + `brew audit` and was installed and run end-to-end (real transfer, sha256 verified) before this.
- **docs/COMPARISON.md**: the `❌ not yet` encryption cell now links to the tracking issue #22, so the roadmap claim points at a real, documented plan rather than a bare "not yet".

winget (microsoft/winget-pkgs#397919) and Scoop (ScoopInstaller/Extras#18225) install lines will be added in a follow-up once those PRs merge — no point documenting a command that 404s until then.