### PR TITLE
Enforce no-clobber atomically and give main() sole ownership of the socket

### DIFF
--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -21,8 +21,8 @@
 #include <set>
 
 #if !defined(_WIN32) && !defined(_WIN64)
-#include <fcntl.h>   // open, O_EXCL, O_NOFOLLOW
-#include <unistd.h>  // read, write, close
+#include <fcntl.h>   // open, O_EXCL, O_NOFOLLOW, AT_FDCWD
+#include <unistd.h>  // read, write, close, link, unlink
 #endif
 
 using namespace std::chrono_literals;
@@ -181,20 +181,29 @@ void syncParentDir(const std::string& path) {
 // path is rejected rather than followed/overwritten. Returns false on I/O error.
 bool writeTempFile(const std::string& tmp, const char* data, size_t len) {
     #if defined(_WIN32) || defined(_WIN64)
-    std::ofstream out(tmp, std::ofstream::binary | std::ofstream::trunc);
-    if (!out.is_open()) return false;
-    out.write(data, static_cast<std::streamsize>(len));
-    out.close();
-    if (!out) return false;
-    // std::ofstream::close only reaches the OS cache; force the payload to disk
-    // before the move so a power loss can't leave a torn/empty output (MoveFileEx
-    // WRITE_THROUGH flushes only cross-volume copies, not a same-volume rename).
-    HANDLE h = CreateFileA(tmp.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr,
-                           OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    // CREATE_NEW mirrors the POSIX O_EXCL below: a file planted at the temp
+    // path fails the create instead of being truncated. FlushFileBuffers forces
+    // the payload to disk before the move so a power loss can't leave a
+    // torn/empty output (MoveFileEx WRITE_THROUGH flushes only cross-volume
+    // copies, not a same-volume rename).
+    HANDLE h = CreateFileA(tmp.c_str(), GENERIC_WRITE, 0, nullptr,
+                           CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (h == INVALID_HANDLE_VALUE) return false;
-    BOOL flushed = FlushFileBuffers(h);
-    CloseHandle(h);
-    return flushed != 0;
+    bool ok = true;
+    for (size_t off = 0; off < len; ) {
+        // WriteFile takes a DWORD count; cap each write at 1 GiB.
+        DWORD chunk = (len - off > 0x40000000u) ? 0x40000000u
+                                                : static_cast<DWORD>(len - off);
+        DWORD wrote = 0;
+        if (!WriteFile(h, data + off, chunk, &wrote, nullptr) || wrote == 0) {
+            ok = false;
+            break;
+        }
+        off += wrote;
+    }
+    if (ok && !FlushFileBuffers(h)) ok = false;
+    if (!CloseHandle(h)) ok = false;
+    return ok;
     #else
     int fd = open(tmp.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0644);
     if (fd < 0) return false;
@@ -235,10 +244,51 @@ bool finalizeReplace(const std::string& tmp, const std::string& target) {
     #endif
 }
 
-// Write len bytes to a randomly-named temp beside `target`, then atomically move
-// it onto `target`. The random suffix keeps a hostile sender from predicting the
-// temp path. Returns a process exit code; on finalize failure the verified temp
-// is kept so no data is lost.
+// Outcome of the no-clobber finalize: moved into place, refused because the
+// target exists, or failed outright.
+enum class Finalize { Ok, Exists, Error };
+
+// Atomically move `tmp` onto `target` only if `target` does not exist. The
+// existence check and the move must be a single operation: a separate
+// exists()+rename() lets a file created between the two be silently replaced,
+// voiding the no-overwrite promise. Windows MoveFileEx without REPLACE_EXISTING
+// refuses an existing target atomically; on POSIX renameatx_np(RENAME_EXCL)
+// (macOS) and link()+unlink() both fail with EEXIST instead of replacing.
+// Filesystems supporting neither (FAT, some network mounts) fall back to
+// check+rename — non-atomic, but no worse than the pre-atomic behaviour.
+Finalize finalizeNoClobber(const std::string& tmp, const std::string& target) {
+    #if defined(_WIN32) || defined(_WIN64)
+    if (MoveFileExA(tmp.c_str(), target.c_str(), MOVEFILE_WRITE_THROUGH) != 0) {
+        return Finalize::Ok;
+    }
+    DWORD err = GetLastError();
+    return (err == ERROR_ALREADY_EXISTS || err == ERROR_FILE_EXISTS)
+        ? Finalize::Exists : Finalize::Error;
+    #else
+    #if defined(__APPLE__)
+    if (renameatx_np(AT_FDCWD, tmp.c_str(), AT_FDCWD, target.c_str(), RENAME_EXCL) == 0) {
+        syncParentDir(target);
+        return Finalize::Ok;
+    }
+    if (errno == EEXIST) return Finalize::Exists;
+    // ENOTSUP and friends (e.g. SMB/NFS mounts): fall through to link().
+    #endif
+    if (link(tmp.c_str(), target.c_str()) == 0) {
+        unlink(tmp.c_str());  // best-effort; a leftover tmp loses no data
+        syncParentDir(target);
+        return Finalize::Ok;
+    }
+    if (errno == EEXIST) return Finalize::Exists;
+    if (fileExists(target)) return Finalize::Exists;
+    return finalizeReplace(tmp, target) ? Finalize::Ok : Finalize::Error;
+    #endif
+}
+
+// Write len bytes to a randomly-named temp beside `target`, then atomically
+// move it onto `target` — replacing an existing file only when --overwrite was
+// given. The random suffix keeps a hostile sender from predicting the temp
+// path. Returns a process exit code; on finalize failure the verified temp is
+// kept so no data is lost.
 int writeVerified(const std::string& target, const char* data, size_t len) {
     std::random_device rd;
     char suffix[24];
@@ -251,12 +301,28 @@ int writeVerified(const std::string& target, const char* data, size_t len) {
         std::remove(tmp.c_str());
         return 2;
     }
-    if (!finalizeReplace(tmp, target)) {
+    if (overwrite) {
+        if (finalizeReplace(tmp, target)) return 0;
         std::cerr << "Error: Failed to finalize " << target
                   << "; verified data kept at " << tmp << std::endl;
         return 2;
     }
-    return 0;
+    switch (finalizeNoClobber(tmp, target)) {
+        case Finalize::Ok:
+            return 0;
+        case Finalize::Exists:
+            // The target appeared after verifyAndWrite's early check (e.g. a
+            // second receiver in the same directory finished first).
+            std::cerr << "Error: output file " << target
+                      << " already exists (use --overwrite to replace it); "
+                      << "verified data kept at " << tmp << std::endl;
+            return 2;
+        case Finalize::Error:
+        default:
+            std::cerr << "Error: Failed to finalize " << target
+                      << "; verified data kept at " << tmp << std::endl;
+            return 2;
+    }
 }
 
 // Write len bytes to `path` (stable name, truncating). On POSIX O_NOFOLLOW
@@ -454,7 +520,9 @@ int verifyAndWrite() {
         return 2;
     }
 
-    // Refuse to clobber an existing file unless the user opted in.
+    // Refuse to clobber an existing file unless the user opted in. This check
+    // fails fast before the temp write; the atomic no-clobber finalize inside
+    // writeVerified is what enforces it when the file appears mid-write.
     if (!overwrite && fileExists(fileName)) {
         std::cerr << "Error: output file " << fileName
                   << " already exists (use --overwrite to replace it)" << std::endl;

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -241,8 +241,8 @@ int run() {
     if (loadFileIntoMemory() != 0) {
         delete[] buffer;
         buffer = nullptr;
-        CLOSE_SOCKET(_socket);
-        CLEANUP_NETWORK();
+        // The socket is main()'s to close (as on every other return path);
+        // closing it here too made main()'s CLOSE_SOCKET a double-close.
         return 1;
     }
     if (verbose) std::cout << "Ok: File successfully copied to RAM" << std::endl;

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -205,6 +205,69 @@ run_announced_name_test() {
 }
 run_announced_name_test
 
+# No-clobber: an existing output file must survive a receive without
+# --overwrite (exit 2, byte-identical content, no leftover temp files), and be
+# replaced once --overwrite is given. Pins the no-clobber contract that the
+# atomic finalize (finalizeNoClobber) enforces even against files that appear
+# mid-write.
+run_no_clobber_test() {
+    local dir="$WORKDIR/no-clobber"
+    mkdir -p "$dir"
+    dd if=/dev/urandom of="$dir/src.bin" bs=1024 count=50 status=none
+    echo "precious local data" > "$dir/out.bin"
+    cp "$dir/out.bin" "$dir/expected.bin"
+
+    echo "==> [no-clobber] receive onto an existing file without --overwrite"
+    ( cd "$dir" && exec "$BINARY" receive out.bin --to 127.0.0.1 \
+          --bind-port 33411 --port 33412 --ttl 5 --delay-ms 0 > recv1.log 2>&1 ) &
+    local rpid=$!
+    sleep 1
+    "$BINARY" send "$dir/src.bin" --to 127.0.0.1 --bind-port 33412 --port 33411 \
+              --ttl 2 --delay-ms 0 > "$dir/send1.log" 2>&1
+
+    local rc=0
+    wait "$rpid" || rc=$?
+    if [ "$rc" -ne 2 ]; then
+        echo "FAIL: [no-clobber] expected receiver exit 2, got $rc"
+        tail -5 "$dir/recv1.log"
+        return 1
+    fi
+    if ! grep -q "already exists" "$dir/recv1.log"; then
+        echo "FAIL: [no-clobber] missing 'already exists' error"
+        tail -5 "$dir/recv1.log"
+        return 1
+    fi
+    if ! cmp -s "$dir/expected.bin" "$dir/out.bin"; then
+        echo "FAIL: [no-clobber] existing file was modified"
+        return 1
+    fi
+    if ls "$dir"/out.bin.part.* >/dev/null 2>&1; then
+        echo "FAIL: [no-clobber] leftover temp files:"
+        ls "$dir"
+        return 1
+    fi
+
+    echo "==> [no-clobber] same receive with --overwrite replaces the file"
+    ( cd "$dir" && exec "$BINARY" receive out.bin --to 127.0.0.1 \
+          --bind-port 33411 --port 33412 --ttl 5 --delay-ms 0 --overwrite \
+          > recv2.log 2>&1 ) &
+    rpid=$!
+    sleep 1
+    "$BINARY" send "$dir/src.bin" --to 127.0.0.1 --bind-port 33412 --port 33411 \
+              --ttl 2 --delay-ms 0 > "$dir/send2.log" 2>&1
+    if ! wait "$rpid"; then
+        echo "FAIL: [no-clobber] receive with --overwrite exited non-zero"
+        tail -5 "$dir/recv2.log"
+        return 1
+    fi
+    if ! cmp -s "$dir/src.bin" "$dir/out.bin"; then
+        echo "FAIL: [no-clobber] --overwrite did not replace the file"
+        return 1
+    fi
+    echo "PASS: [no-clobber] refused without --overwrite, replaced with it"
+}
+run_no_clobber_test
+
 # Resume: interrupt a slow receive with SIGINT, then finish it with --resume.
 # Timing-based, so if no snapshot lands (transfer finished or nothing arrived in
 # the window) it SKIPs; but once a snapshot exists, resume must succeed or FAIL.


### PR DESCRIPTION
Closes the three findings from the external review (Codex), plus an e2e test for the no-clobber contract.

## 1. `--overwrite` guard was not atomic (TOCTOU)

`verifyAndWrite` checked `fileExists()` and then finalized via a rename that always replaces (`std::rename` / `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`). The window between check and rename spans the whole temp write **plus fsync** (`F_FULLFSYNC` on macOS), so a file created meanwhile — e.g. a second receiver finishing first in the same directory — was silently clobbered. The `ifstream`-based check also treated an existing but unreadable file (EACCES) as absent.

Fix: the finalize is split in two.

- `finalizeReplace` — unchanged replacing semantics, used only with `--overwrite`.
- `finalizeNoClobber` — the existence check is part of the move itself:
  - Windows: `MoveFileEx` **without** `MOVEFILE_REPLACE_EXISTING` (atomically refuses an existing target);
  - macOS: `renameatx_np(RENAME_EXCL)`;
  - other POSIX / macOS fallback: `link()` + `unlink()` (fails with `EEXIST` instead of replacing);
  - filesystems supporting neither (FAT, some network mounts): check+rename — non-atomic, but no worse than before.

The early `fileExists()` check stays as a fast refusal before the temp write + fsync; when the race fires anyway, the receiver exits 2 and keeps the verified temp, naming it in the error, so no received data is lost. While in this code, the Windows temp write now uses `CREATE_NEW` (mirroring the POSIX `O_EXCL` guard against a planted temp path) and a single handle for both write and flush.

Both POSIX primitives were probe-tested on APFS: move onto an absent target succeeds, an existing target refuses with `EEXIST`, and the refused move leaves the temp in place.

## 2. Sender double-close on the file-read error path

`Sender::run()` closed the socket and tore down Winsock when `loadFileIntoMemory()` failed, then `main()` closed the same socket again. Harmless today (no fd is opened in between), but a latent bug. The extra close is dropped: `main()` owns the socket on every path, matching `Receiver::run()`.

## 3. Stale local `build/`

`build/CMakeCache.txt` still pointed at the pre-rename `File-Broadcaster` path; regenerated locally with `cmake --fresh` (nothing to commit — `build/` is ignored).

## Tests

New `[no-clobber]` e2e case: receive onto an existing file without `--overwrite` exits 2, leaves the file byte-identical with no leftover temp files, and the same receive with `--overwrite` replaces it.

`ctest` locally on macOS: `unit`, `e2e`, `e2e_lossy` — 3/3 passed.