### PR TITLE
Use disk-backed transfer storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,20 @@ if(BUILD_TESTING)
                 ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE}"
                 TIMEOUT 120
             )
+
+            # Corrupting variant: a Python UDP proxy flips one payload byte so the
+            # reassembled file fails its SHA-256, exercising verifyAndWrite's
+            # checksum-mismatch cleanup. Also needs Python 3.
+            add_test(
+                NAME e2e_corrupt
+                COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/e2e_corrupt.sh
+            )
+            set_tests_properties(e2e_corrupt PROPERTIES
+                ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE}"
+                TIMEOUT 120
+            )
         else()
-            message(STATUS "Python 3 not found — skipping e2e_lossy test")
+            message(STATUS "Python 3 not found — skipping e2e_lossy and e2e_corrupt tests")
         endif()
     endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ If your platform isn't covered, see
   machines simultaneously
 - **LAN parties** — everyone gets the mod in the time of one transfer
 
-One file per run, up to 4 GiB — the whole file is buffered in RAM on each
-side (see [Limitations](#limitations)).
+One file per run, up to 4 GiB with the current wire format — transfers are
+stored on disk as they arrive, not buffered wholly in RAM (see
+[Limitations](#limitations)).
 
 ## How It Compares
 
@@ -239,15 +240,15 @@ The snapshot is deleted once the file completes and its checksum verifies.
 
 ## Limitations
 
-- The whole file is held in RAM on both sides. The receiver enforces a 4 GiB
-  cap on the announced file size; the sender rejects files that do not fit the
-  4-byte wire size field.
-- `--resume` recovers from Ctrl+C and timeouts (the snapshot is written on exit);
-  a hard kill (SIGKILL) or power loss mid-transfer can still lose the in-flight
-  progress. The snapshot is the whole buffer written synchronously, so
-  interrupting a multi-gigabyte transfer adds a short exit delay while it flushes.
-  The `.part`/`.part.idx` files use stable, predictable names in the working
-  directory, so run the receiver from a directory only you can write to.
+- The v3 wire format stores the file size and part index in 4-byte fields. The
+  receiver enforces a 4 GiB cap on the announced file size; the sender rejects
+  files that do not fit the current wire-size field.
+- Receivers need enough free disk space for the in-progress `.part` file beside
+  the final output. With `--resume`, the `.part` file and its `.part.idx` bitmap
+  are kept after Ctrl+C or a timeout so a later run can continue. A hard kill
+  (SIGKILL) or power loss mid-transfer can still lose the latest unflushed
+  progress. The `.part`/`.part.idx` files use stable, predictable names in the
+  working directory, so run the receiver from a directory only you can write to.
 - No authentication. Any host on the same LAN can announce a transfer and any
   receiver bound to the chosen port will accept it. The SHA-256 check catches
   accidental corruption, not a deliberately crafted stream.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ The snapshot is deleted once the file completes and its checksum verifies.
 - The v3 wire format stores the file size and part index in 4-byte fields. The
   receiver enforces a 4 GiB cap on the announced file size; the sender rejects
   files that do not fit the current wire-size field.
+- The sender streams payload from the source path after announcing its SHA-256.
+  Do not modify, truncate, replace, or delete the source file until the transfer
+  has finished, including any resend phase; otherwise receivers will reject the
+  result with a checksum mismatch or the sender will abort on a read error.
 - Receivers need enough free disk space for the in-progress `.part` file beside
   the final output. With `--resume`, the `.part` file and its `.part.idx` bitmap
   are kept after Ctrl+C or a timeout so a later run can continue. A hard kill

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -50,6 +50,11 @@ these 10 bytes.
    it out (atomically, via a temp file and rename) if the digest matches;
    otherwise it reports corruption and fails.
 
+The sender reads the source file from disk when hashing for `ANNOUNCE` and
+again when sending or resending chunks. The source file must remain unchanged
+for the full transfer; a concurrent modification makes the transferred bytes no
+longer match the announced digest.
+
 Because every `TRANSFER` is addressed to the broadcast/multicast group rather
 than to individual receivers, the cost of a transfer does not grow with the
 number of receivers — and a `RESEND` requested by one receiver repairs that

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -35,10 +35,10 @@ these 10 bytes.
 
 1. The sender broadcasts an `ANNOUNCE` carrying a random session id, the total
    file size, the chunk size, the file's SHA-256, and its name.
-2. Each receiver latches that session, allocates a buffer, and clears its part
-   registry. The chunk size is taken from the announcement, so sender and
-   receivers never disagree about part boundaries even with mismatched `--mtu`
-   settings.
+2. Each receiver latches that session, creates an on-disk `.part` file, and
+   clears its part registry. The chunk size is taken from the announcement, so
+   sender and receivers never disagree about part boundaries even with
+   mismatched `--mtu` settings.
 3. The sender splits the file into chunk-sized pieces and broadcasts each one
    as a `TRANSFER` packet at the configured rate.
 4. The sender broadcasts `FINISH` when all chunks have been sent.

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -21,5 +21,4 @@ addr_len server_address_length = sizeof(server_address);
 addr_len client_address_length = sizeof(client_address);
 
 size_t file_length = 0;
-char*  file        = nullptr;
 char*  buffer      = nullptr;

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -30,7 +30,6 @@ extern addr_len server_address_length;
 extern addr_len client_address_length;
 
 extern size_t file_length; // File size in bytes
-extern char*  file;        // Pointer to file in RAM
-extern char*  buffer;      // Pointer to buffer
+extern char*  buffer;      // Packet buffer
 
 #endif //FILECAST_CONFIG_H

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -16,12 +16,12 @@
 #include <csignal>
 #include <string>
 #include <algorithm>
-#include <random>
 #include <vector>
 #include <set>
 
 #if !defined(_WIN32) && !defined(_WIN64)
 #include <fcntl.h>   // open, O_EXCL, O_NOFOLLOW, AT_FDCWD
+#include <sys/stat.h>
 #include <unistd.h>  // read, write, close, link, unlink
 #endif
 
@@ -43,9 +43,9 @@ void installSignalHandlers() {
 #endif
 }
 
-// Hard upper bound on the file size announced by a sender. We allocate the file
-// in RAM, so anything larger than this would either fail or cause OOM. Adjust
-// only if you know the receiver has enough memory.
+// Hard upper bound imposed by the v3 wire format: file_size is a 4-byte field.
+// Disk-backed storage removes the RAM pressure, but v3 still cannot represent
+// anything larger than this without a protocol bump.
 constexpr size_t MAX_FILE_LENGTH = 4ULL * 1024 * 1024 * 1024; // 4 GiB
 
 // Session the receiver is currently bound to. The sender stamps a random id into
@@ -81,6 +81,16 @@ std::string announced_name;
 // bytes that drives it.
 Progress::Reporter reporter;
 size_t received_bytes = 0;
+std::string part_path;
+bool storage_ready = false;
+bool storage_failed = false;
+
+#if defined(_WIN32) || defined(_WIN64)
+HANDLE part_handle = INVALID_HANDLE_VALUE;
+#else
+int part_fd = -1;
+int durableSync(int fd);
+#endif
 
 /**
  * List of received parts
@@ -103,6 +113,138 @@ std::vector<size_t> getEmptyParts() {
     return result;
 }
 
+std::string snapshotPartPath() {
+    return fileName + ".part";
+}
+
+void closePartFile(bool flush) {
+    #if defined(_WIN32) || defined(_WIN64)
+    if (part_handle == INVALID_HANDLE_VALUE) return;
+    if (flush) FlushFileBuffers(part_handle);
+    CloseHandle(part_handle);
+    part_handle = INVALID_HANDLE_VALUE;
+    #else
+    if (part_fd < 0) return;
+    if (flush) durableSync(part_fd);
+    close(part_fd);
+    part_fd = -1;
+    #endif
+}
+
+bool openPartFile(bool reuse_existing) {
+    closePartFile(false);
+    part_path = snapshotPartPath();
+    storage_ready = false;
+    storage_failed = false;
+
+    #if defined(_WIN32) || defined(_WIN64)
+    DWORD disposition = reuse_existing ? OPEN_EXISTING : CREATE_ALWAYS;
+    part_handle = CreateFileA(part_path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr,
+                              disposition, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (part_handle == INVALID_HANDLE_VALUE) return false;
+
+    LARGE_INTEGER pos;
+    if (reuse_existing) {
+        if (!GetFileSizeEx(part_handle, &pos) ||
+            static_cast<uint64_t>(pos.QuadPart) != static_cast<uint64_t>(file_length)) {
+            closePartFile(false);
+            return false;
+        }
+    } else {
+        pos.QuadPart = static_cast<LONGLONG>(file_length);
+        if (!SetFilePointerEx(part_handle, pos, nullptr, FILE_BEGIN) ||
+            !SetEndOfFile(part_handle)) {
+            closePartFile(false);
+            return false;
+        }
+    }
+    #else
+    int flags = O_RDWR | O_CREAT | O_NOFOLLOW;
+    if (!reuse_existing) flags |= O_TRUNC;
+    part_fd = open(part_path.c_str(), flags, 0644);
+    if (part_fd < 0) return false;
+
+    if (reuse_existing) {
+        struct stat st;
+        if (fstat(part_fd, &st) != 0 || st.st_size < 0 ||
+            static_cast<size_t>(st.st_size) != file_length) {
+            closePartFile(false);
+            return false;
+        }
+    } else if (ftruncate(part_fd, static_cast<off_t>(file_length)) != 0) {
+        closePartFile(false);
+        return false;
+    }
+    #endif
+
+    storage_ready = true;
+    return true;
+}
+
+bool writePartAt(size_t offset, const char* data, size_t len) {
+    if (!storage_ready) return false;
+    #if defined(_WIN32) || defined(_WIN64)
+    LARGE_INTEGER pos;
+    pos.QuadPart = static_cast<LONGLONG>(offset);
+    if (!SetFilePointerEx(part_handle, pos, nullptr, FILE_BEGIN)) return false;
+    size_t off = 0;
+    while (off < len) {
+        DWORD chunk = (len - off > 0x40000000u) ? 0x40000000u
+                                                : static_cast<DWORD>(len - off);
+        DWORD wrote = 0;
+        if (!WriteFile(part_handle, data + off, chunk, &wrote, nullptr) || wrote == 0) {
+            return false;
+        }
+        off += wrote;
+    }
+    return true;
+    #else
+    size_t done = 0;
+    while (done < len) {
+        ssize_t w = pwrite(part_fd, data + done, len - done,
+                           static_cast<off_t>(offset + done));
+        if (w < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (w == 0) return false;
+        done += static_cast<size_t>(w);
+    }
+    return true;
+    #endif
+}
+
+bool hashPartFile(uint8_t out[32]) {
+    closePartFile(true);
+    std::ifstream in(part_path, std::ifstream::binary);
+    if (!in.is_open()) return false;
+
+    Sha256::Ctx ctx;
+    Sha256::init(ctx);
+    std::vector<char> hash_buf(1024 * 1024);
+    size_t total = 0;
+    while (in.good()) {
+        in.read(hash_buf.data(), static_cast<std::streamsize>(hash_buf.size()));
+        std::streamsize got = in.gcount();
+        if (got > 0) {
+            Sha256::update(ctx, reinterpret_cast<const uint8_t*>(hash_buf.data()),
+                           static_cast<size_t>(got));
+            total += static_cast<size_t>(got);
+        }
+        if (got == 0) break;
+    }
+    if (total != file_length) return false;
+    Sha256::finish(ctx, out);
+    return true;
+}
+
+void removePartFiles() {
+    closePartFile(false);
+    std::remove(snapshotPartPath().c_str());
+    std::remove((fileName + ".part.idx").c_str());
+    storage_ready = false;
+}
+
 // Validate and store one TRANSFER packet, parsing it from scratch — the packet
 // may come from the main loop or the recovery loop, and full self-validation
 // keeps the two call sites from ever drifting apart. Returns true when a new
@@ -122,12 +264,16 @@ bool handleTransfer(const char* buf, int64_t length) {
 
     // For non-final parts size must equal the chunk size; for the final part it
     // must equal the remaining bytes. Anything else is malformed and would
-    // either silently zero-pad data or write past the file buffer.
+    // either silently zero-pad data or write past the output file.
     if (size != Protocol::expectedPartSize(part, file_length, chunk_size)) return false;
     if (static_cast<size_t>(length) < size + Protocol::TRANSFER_HEADER) return false;
 
+    if (!writePartAt(part * chunk_size, buf + Protocol::TRANSFER_HEADER, size)) {
+        std::cerr << "Error: Failed to write received data to " << part_path << std::endl;
+        storage_failed = true;
+        return false;
+    }
     parts.insert(part);
-    memcpy(file + part * chunk_size, buf + Protocol::TRANSFER_HEADER, size);
     received_bytes += size;
     reporter.update(received_bytes);
     if (verbose) std::cout << "Receive " << part << " part with size " << size << std::endl;
@@ -175,60 +321,8 @@ void syncParentDir(const std::string& path) {
 }
 #endif
 
-// Write len bytes to a fresh temp file `tmp`, flushing the data to stable storage
-// before returning so the reassembled output survives an OS crash or power loss.
-// On POSIX O_EXCL|O_NOFOLLOW means a symlink or pre-existing file planted at that
-// path is rejected rather than followed/overwritten. Returns false on I/O error.
-bool writeTempFile(const std::string& tmp, const char* data, size_t len) {
-    #if defined(_WIN32) || defined(_WIN64)
-    // CREATE_NEW mirrors the POSIX O_EXCL below: a file planted at the temp
-    // path fails the create instead of being truncated. FlushFileBuffers forces
-    // the payload to disk before the move so a power loss can't leave a
-    // torn/empty output (MoveFileEx WRITE_THROUGH flushes only cross-volume
-    // copies, not a same-volume rename).
-    HANDLE h = CreateFileA(tmp.c_str(), GENERIC_WRITE, 0, nullptr,
-                           CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (h == INVALID_HANDLE_VALUE) return false;
-    bool ok = true;
-    for (size_t off = 0; off < len; ) {
-        // WriteFile takes a DWORD count; cap each write at 1 GiB.
-        DWORD chunk = (len - off > 0x40000000u) ? 0x40000000u
-                                                : static_cast<DWORD>(len - off);
-        DWORD wrote = 0;
-        if (!WriteFile(h, data + off, chunk, &wrote, nullptr) || wrote == 0) {
-            ok = false;
-            break;
-        }
-        off += wrote;
-    }
-    if (ok && !FlushFileBuffers(h)) ok = false;
-    if (!CloseHandle(h)) ok = false;
-    return ok;
-    #else
-    int fd = open(tmp.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0644);
-    if (fd < 0) return false;
-    bool ok = true;
-    for (size_t off = 0; off < len; ) {
-        ssize_t w = write(fd, data + off, len - off);
-        if (w < 0) {
-            if (errno == EINTR) continue;  // interrupted by a signal — retry
-            ok = false;
-            break;
-        }
-        if (w == 0) {  // not expected for a regular file
-            ok = false;
-            break;
-        }
-        off += static_cast<size_t>(w);
-    }
-    if (ok && durableSync(fd) != 0) ok = false;  // flush data to disk before rename
-    if (close(fd) != 0) ok = false;
-    return ok;
-    #endif
-}
-
 // Atomically move `tmp` onto `target`, replacing any existing file. The payload
-// was already flushed by writeTempFile; here we make the rename itself durable.
+// was already flushed by the caller; here we make the rename itself durable.
 // On Windows MoveFileEx replaces atomically (a plain rename can't clobber) and
 // WRITE_THROUGH flushes the operation; on POSIX rename is atomic and we flush the
 // directory so the rename survives a crash. Returns false on failure, leaving the
@@ -284,43 +378,32 @@ Finalize finalizeNoClobber(const std::string& tmp, const std::string& target) {
     #endif
 }
 
-// Write len bytes to a randomly-named temp beside `target`, then atomically
-// move it onto `target` — replacing an existing file only when --overwrite was
-// given. The random suffix keeps a hostile sender from predicting the temp
-// path. Returns a process exit code; on finalize failure the verified temp is
-// kept so no data is lost.
-int writeVerified(const std::string& target, const char* data, size_t len) {
-    std::random_device rd;
-    char suffix[24];
-    snprintf(suffix, sizeof(suffix), ".part.%08x%08x",
-             static_cast<unsigned>(rd()), static_cast<unsigned>(rd()));
-    const std::string tmp = target + suffix;
-
-    if (!writeTempFile(tmp, data, len)) {
-        std::cerr << "Error: Failed to write output file " << tmp << std::endl;
-        std::remove(tmp.c_str());
-        return 2;
-    }
+// Move the verified on-disk .part file into place. On failure the .part file is
+// kept so the user does not lose a completed transfer.
+int finalizeVerifiedPart(const std::string& target) {
+    closePartFile(true);
     if (overwrite) {
-        if (finalizeReplace(tmp, target)) return 0;
+        if (finalizeReplace(part_path, target)) {
+            storage_ready = false;
+            return 0;
+        }
         std::cerr << "Error: Failed to finalize " << target
-                  << "; verified data kept at " << tmp << std::endl;
+                  << "; verified data kept at " << part_path << std::endl;
         return 2;
     }
-    switch (finalizeNoClobber(tmp, target)) {
+    switch (finalizeNoClobber(part_path, target)) {
         case Finalize::Ok:
+            storage_ready = false;
             return 0;
         case Finalize::Exists:
-            // The target appeared after verifyAndWrite's early check (e.g. a
-            // second receiver in the same directory finished first).
             std::cerr << "Error: output file " << target
                       << " already exists (use --overwrite to replace it); "
-                      << "verified data kept at " << tmp << std::endl;
+                      << "verified data kept at " << part_path << std::endl;
             return 2;
         case Finalize::Error:
         default:
             std::cerr << "Error: Failed to finalize " << target
-                      << "; verified data kept at " << tmp << std::endl;
+                      << "; verified data kept at " << part_path << std::endl;
             return 2;
     }
 }
@@ -358,9 +441,8 @@ bool writeRawFile(const std::string& path, const char* data, size_t len) {
 
 // Read up to `max` bytes of `path` into `out`, reporting the count in `got`.
 // On POSIX O_NOFOLLOW refuses to follow a symlink planted at that path, matching
-// the write side (writeRawFile/writeVerified) — otherwise a hostile symlink could
-// make resume slurp an arbitrary file the receiver can read into the buffer that
-// saveSnapshot later writes back out. Returns false on open/read error.
+// the write side — otherwise a hostile symlink could make resume trust an
+// arbitrary file the receiver can read. Returns false on open/read error.
 bool readRawFile(const std::string& path, char* out, size_t max, size_t& got) {
     #if defined(_WIN32) || defined(_WIN64)
     std::ifstream in(path, std::ifstream::binary);
@@ -390,18 +472,14 @@ bool readRawFile(const std::string& path, char* out, size_t max, size_t& got) {
 // snapshot header: "FCIDX1"+NUL(7) + sha256(32) + file_length(8) + chunk(4).
 constexpr size_t SNAPSHOT_HEADER = 51;
 
-// Persist the partial buffer to <name>.part and a bitmap of received parts to
+// Flush the partial <name>.part file and persist a bitmap of received parts to
 // <name>.part.idx, so a later --resume run keyed on the file's SHA-256 can pick
 // up where this one left off. Best-effort: a failure only means no resume.
 // Gated on --resume so a plain receive never leaves surprise .part files behind
 // (nor pays the synchronous whole-buffer write) when interrupted.
 void saveSnapshot() {
-    if (!resume || file == nullptr || !have_session) return;
-    const std::string partPath = fileName + ".part";
-    if (!writeRawFile(partPath, file, file_length)) {
-        std::cerr << "Warning: could not save resume snapshot to " << partPath << std::endl;
-        return;
-    }
+    if (!resume || !storage_ready || !have_session) return;
+    closePartFile(true);
     size_t total = totalParts();
     std::vector<char> idx(SNAPSHOT_HEADER + (total + 7) / 8, 0);
     memcpy(idx.data(), "FCIDX1", 7);  // 6 chars + trailing NUL
@@ -410,6 +488,7 @@ void saveSnapshot() {
     Utils::writeBytesFromNumber(idx.data() + 47, chunk_size,  4);
     for (size_t p : parts) idx[SNAPSHOT_HEADER + p / 8] |= static_cast<char>(1 << (p % 8));
     writeRawFile(fileName + ".part.idx", idx.data(), idx.size());
+    openPartFile(true);
 }
 
 // Remove the snapshot once the transfer has completed and been written out.
@@ -418,9 +497,9 @@ void discardSnapshot() {
     std::remove((fileName + ".part.idx").c_str());
 }
 
-// Try to load a matching snapshot into `file`/`parts`. Only reuses data whose
-// idx records the same SHA-256, size and chunk as the current transfer. Returns
-// true on a successful resume (file/parts/received_bytes are populated).
+// Try to load a matching snapshot into the part file and part registry. Only
+// reuses data whose idx records the same SHA-256, size and chunk as the current
+// transfer. Returns true on a successful resume.
 bool tryResume(size_t announced, size_t chunk, const uint8_t hash[32]) {
     size_t total  = Protocol::totalParts(announced, chunk);
     size_t bmSize = (total + 7) / 8;
@@ -437,16 +516,8 @@ bool tryResume(size_t announced, size_t chunk, const uint8_t hash[32]) {
     if (Utils::getNumberFromBytes(idx.data() + 47, 4) != chunk) return false;
     const char* bm = idx.data() + SNAPSHOT_HEADER;
 
-    char* buf = new (std::nothrow) char[announced];
-    if (!buf) return false;
-    got = 0;
-    if (!readRawFile(fileName + ".part", buf, announced, got) || got != announced) {
-        delete[] buf;
-        return false;
-    }
+    if (!openPartFile(true)) return false;
 
-    delete[] file;
-    file = buf;
     parts.clear();
     received_bytes = 0;
     for (size_t p = 0; p < total; ++p) {
@@ -462,14 +533,13 @@ bool tryResume(size_t announced, size_t chunk, const uint8_t hash[32]) {
 int onInterrupt(char* buffer) {
     reporter.finish();
     saveSnapshot();
-    if (resume && file != nullptr) {
+    if (resume && storage_ready) {
         std::cerr << "\nInterrupted; progress saved (retry with --resume)" << std::endl;
     } else {
         std::cerr << "\nInterrupted" << std::endl;
+        removePartFiles();
     }
     delete[] buffer;
-    delete[] file;
-    file = nullptr;
     return 130;
 }
 
@@ -480,12 +550,12 @@ int onInterrupt(char* buffer) {
 int onTimeout(char* buffer) {
     reporter.finish();
     saveSnapshot();
-    if (resume && file != nullptr) {
+    if (resume && storage_ready) {
         std::cerr << "Transfer timed out; progress saved (retry with --resume)" << std::endl;
+    } else {
+        removePartFiles();
     }
     delete[] buffer;
-    delete[] file;
-    file = nullptr;
     return 2;
 }
 
@@ -496,9 +566,8 @@ int onRecoveryTimeout(size_t missing) {
     saveSnapshot();     // keep progress so a later --resume can finish it
     std::cerr << "Error: Transfer timed out with " << missing << " part(s) missing";
     if (resume) std::cerr << "; progress saved (retry with --resume)";
+    else removePartFiles();
     std::cerr << std::endl;
-    delete[] file;
-    file = nullptr;
     return 2;
 }
 
@@ -508,33 +577,34 @@ int verifyAndWrite() {
     reporter.finish();
 
     uint8_t got[32];
-    Sha256::hash(file, file_length, got);
+    if (!hashPartFile(got)) {
+        std::cerr << "Error: Failed to read received file for checksum" << std::endl;
+        if (resume) discardSnapshot();
+        else removePartFiles();
+        return 2;
+    }
     if (memcmp(got, expected_hash, 32) != 0) {
         std::cerr << "Error: checksum mismatch — received file is corrupt" << std::endl;
         // A resumed snapshot whose bytes are corrupt (e.g. torn write) would fail
         // here forever; drop it so the next --resume starts clean instead of
         // reloading the same poison.
         if (resume) discardSnapshot();
-        delete[] file;
-        file = nullptr;
+        else removePartFiles();
         return 2;
     }
 
     // Refuse to clobber an existing file unless the user opted in. This check
-    // fails fast before the temp write; the atomic no-clobber finalize inside
-    // writeVerified is what enforces it when the file appears mid-write.
+    // fails fast before the atomic no-clobber finalize, which still enforces it
+    // if the file appears mid-write.
     if (!overwrite && fileExists(fileName)) {
         std::cerr << "Error: output file " << fileName
                   << " already exists (use --overwrite to replace it)" << std::endl;
-        delete[] file;
-        file = nullptr;
+        if (!resume) removePartFiles();
         return 2;
     }
 
-    int wc = writeVerified(fileName, file, file_length);
+    int wc = finalizeVerifiedPart(fileName);
     if (wc != 0) {
-        delete[] file;
-        file = nullptr;
         return wc;
     }
     discardSnapshot();  // transfer complete — the .part snapshot is no longer needed
@@ -548,8 +618,6 @@ int verifyAndWrite() {
     }
     std::cout << "; sha256 verified" << std::endl;
 
-    delete[] file;
-    file = nullptr;
     return 0;
 }
 
@@ -563,8 +631,7 @@ int checkParts() {
     char* buffer = new (std::nothrow) char[bufcap];
     if (!buffer) {
         std::cerr << "Error: Can't allocate receive buffer" << std::endl;
-        delete[] file;
-        file = nullptr;
+        removePartFiles();
         return 1;
     }
 
@@ -608,6 +675,11 @@ int checkParts() {
                 continue;
             }
             if (handleTransfer(buffer, static_cast<int64_t>(length))) progressed = true;
+            if (storage_failed) {
+                delete[] buffer;
+                if (!resume) removePartFiles();
+                return 2;
+            }
         }
 
         // A new part refreshes ttl; a round with no progress counts down toward
@@ -667,14 +739,13 @@ bool growRecvBuffer(char*& buf, size_t& bufcap, int& exit_code) {
     return true;
 }
 
-// Allocate a fresh (empty) file buffer for a new transfer.
-bool allocateFileFresh(int& exit_code) {
-    delete[] file;
+// Create a fresh on-disk part file for a new transfer.
+bool createPartFresh(int& exit_code) {
+    closePartFile(false);
     parts.clear();
     received_bytes = 0;
-    file = new (std::nothrow) char[file_length];
-    if (!file) {
-        std::cerr << "Error: Can't allocate " << file_length << " bytes" << std::endl;
+    if (!openPartFile(false)) {
+        std::cerr << "Error: Can't create temporary output file " << snapshotPartPath() << std::endl;
         exit_code = 1;
         return false;
     }
@@ -687,7 +758,7 @@ bool prepareStorage(char*& buf, size_t& bufcap, size_t announced, size_t chunk,
                     bool& resumed, int& exit_code) {
     if (!growRecvBuffer(buf, bufcap, exit_code)) return false;
     resumed = resume && tryResume(announced, chunk, expected_hash);
-    if (!resumed && !allocateFileFresh(exit_code)) return false;
+    if (!resumed && !createPartFresh(exit_code)) return false;
     return true;
 }
 
@@ -720,7 +791,7 @@ bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incomin
     if (!announceValid(announced, incoming_cs, exit_code)) return false;
 
     // Duplicate retransmission of the same ANNOUNCE: keep accumulated parts.
-    if (file != nullptr && announced == file_length && incoming_cs == chunk_size) return true;
+    if (storage_ready && announced == file_length && incoming_cs == chunk_size) return true;
 
     session_id   = incoming_sid;
     have_session = true;
@@ -783,7 +854,8 @@ int dispatchPacket(char*& buf, size_t& bufcap, int64_t length, bool& finish) {
             break;
         }
         case Protocol::Type::Transfer:
-            if (file != nullptr && handleTransfer(buf, length)) ttl = ttl_max;
+            if (storage_ready && handleTransfer(buf, length)) ttl = ttl_max;
+            if (storage_failed) return 2;
             break;
         case Protocol::Type::Finish:
             handleFinish(h.session, finish);
@@ -815,7 +887,7 @@ int run() {
         // Sender finished transferring — move to the recovery phase (or bail if
         // we joined too late to ever have received the ANNOUNCE).
         if (finish) {
-            if (file != nullptr) {
+            if (storage_ready) {
                 delete[] buffer;
                 return checkParts();
             }
@@ -843,8 +915,7 @@ int run() {
         int code = dispatchPacket(buffer, bufcap, static_cast<int64_t>(length), finish);
         if (code >= 0) {
             delete[] buffer;
-            delete[] file;
-            file = nullptr;
+            if (code != 0 && !resume) removePartFiles();
             return code;
         }
     }

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -218,24 +218,7 @@ bool hashPartFile(uint8_t out[32]) {
     closePartFile(true);
     std::ifstream in(part_path, std::ifstream::binary);
     if (!in.is_open()) return false;
-
-    Sha256::Ctx ctx;
-    Sha256::init(ctx);
-    std::vector<char> hash_buf(1024 * 1024);
-    size_t total = 0;
-    while (in.good()) {
-        in.read(hash_buf.data(), static_cast<std::streamsize>(hash_buf.size()));
-        std::streamsize got = in.gcount();
-        if (got > 0) {
-            Sha256::update(ctx, reinterpret_cast<const uint8_t*>(hash_buf.data()),
-                           static_cast<size_t>(got));
-            total += static_cast<size_t>(got);
-        }
-        if (got == 0) break;
-    }
-    if (total != file_length) return false;
-    Sha256::finish(ctx, out);
-    return true;
+    return Sha256::hashStream(in, file_length, out);
 }
 
 void removePartFiles() {
@@ -477,8 +460,8 @@ constexpr size_t SNAPSHOT_HEADER = 51;
 // up where this one left off. Best-effort: a failure only means no resume.
 // Gated on --resume so a plain receive never leaves surprise .part files behind
 // (nor pays the synchronous whole-buffer write) when interrupted.
-void saveSnapshot() {
-    if (!resume || !storage_ready || !have_session) return;
+bool saveSnapshot() {
+    if (!resume || !storage_ready || !have_session) return false;
     closePartFile(true);
     size_t total = totalParts();
     std::vector<char> idx(SNAPSHOT_HEADER + (total + 7) / 8, 0);
@@ -487,8 +470,7 @@ void saveSnapshot() {
     Utils::writeBytesFromNumber(idx.data() + 39, file_length, 8);
     Utils::writeBytesFromNumber(idx.data() + 47, chunk_size,  4);
     for (size_t p : parts) idx[SNAPSHOT_HEADER + p / 8] |= static_cast<char>(1 << (p % 8));
-    writeRawFile(fileName + ".part.idx", idx.data(), idx.size());
-    openPartFile(true);
+    return writeRawFile(fileName + ".part.idx", idx.data(), idx.size());
 }
 
 // Remove the snapshot once the transfer has completed and been written out.
@@ -532,8 +514,8 @@ bool tryResume(size_t announced, size_t chunk, const uint8_t hash[32]) {
 // Snapshot the partial file and clean up after Ctrl+C/SIGTERM. Returns 130.
 int onInterrupt(char* buffer) {
     reporter.finish();
-    saveSnapshot();
-    if (resume && storage_ready) {
+    bool saved = saveSnapshot();
+    if (saved) {
         std::cerr << "\nInterrupted; progress saved (retry with --resume)" << std::endl;
     } else {
         std::cerr << "\nInterrupted" << std::endl;
@@ -549,8 +531,8 @@ int onInterrupt(char* buffer) {
 // clean up. Returns 2. Mirrors the checkParts timeout path so both timeouts save.
 int onTimeout(char* buffer) {
     reporter.finish();
-    saveSnapshot();
-    if (resume && storage_ready) {
+    bool saved = saveSnapshot();
+    if (saved) {
         std::cerr << "Transfer timed out; progress saved (retry with --resume)" << std::endl;
     } else {
         removePartFiles();
@@ -563,9 +545,9 @@ int onTimeout(char* buffer) {
 // caller has already freed its receive buffer. Returns 2.
 int onRecoveryTimeout(size_t missing) {
     reporter.finish();  // clear the bar before the error line
-    saveSnapshot();     // keep progress so a later --resume can finish it
+    bool saved = saveSnapshot();  // keep progress so a later --resume can finish it
     std::cerr << "Error: Transfer timed out with " << missing << " part(s) missing";
-    if (resume) std::cerr << "; progress saved (retry with --resume)";
+    if (saved) std::cerr << "; progress saved (retry with --resume)";
     else removePartFiles();
     std::cerr << std::endl;
     return 2;

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -179,7 +179,7 @@ bool sendAnnounce() {
 }
 
 // Serve RESEND requests until ttl expires, re-announcing FINISH periodically.
-// Returns how many parts were re-sent on request.
+// Returns false on a fatal read error; reports successful re-sends in `resent`.
 bool serveResends(size_t total_parts, size_t& resent) {
     int64_t lastFinishSendTime = 0;
 

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <map>
 #include <random>
+#include <vector>
 
 using namespace std::chrono_literals;
 
@@ -44,6 +45,17 @@ std::string baseName(const std::string& path) {
  * This container contains part number and time when the part was sent
  */
 std::map<size_t, int64_t> sent_part;
+std::ifstream input_file;
+
+constexpr size_t HASH_BUFFER_SIZE = 1024 * 1024;
+
+bool readFileAt(size_t offset, char* out, size_t len) {
+    input_file.clear();
+    input_file.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
+    if (!input_file.good()) return false;
+    input_file.read(out, static_cast<std::streamsize>(len));
+    return static_cast<size_t>(input_file.gcount()) == len;
+}
 
 void sendPart(size_t part_index) {
     size_t offset        = part_index * static_cast<size_t>(mtu);
@@ -53,7 +65,10 @@ void sendPart(size_t part_index) {
     Protocol::writeHeader(buffer, Protocol::Type::Transfer, session_id);
     Protocol::putU32(buffer + Protocol::HEADER_SIZE,     static_cast<uint32_t>(part_index));
     Protocol::putU32(buffer + Protocol::HEADER_SIZE + 4, static_cast<uint32_t>(packet_length));
-    memcpy(buffer + Protocol::TRANSFER_HEADER, file + offset, packet_length);
+    if (!readFileAt(offset, buffer + Protocol::TRANSFER_HEADER, packet_length)) {
+        std::cerr << "Warning: Failed to read part " << part_index << std::endl;
+        return;
+    }
 
     auto sent = sendto(_socket, buffer, static_cast<int>(packet_length + Protocol::TRANSFER_HEADER), 0,
                        reinterpret_cast<sockaddr*>(&broadcast_address), sizeof(broadcast_address));
@@ -80,23 +95,22 @@ void sendFinish() {
     }
 }
 
-// Load the whole file into the global `file` buffer. Returns 0 on success, or
-// an error code after cleaning up the file buffer.
-int loadFileIntoMemory() {
-    std::ifstream input(fileName, std::ios::binary);
-    if (!input.is_open()) {
+// Open the input file and validate the v3 wire-size limit.
+int openInputFile() {
+    input_file.open(fileName, std::ios::binary);
+    if (!input_file.is_open()) {
         std::cerr << "Error: Can't open file " << fileName << std::endl;
         return 1;
     }
 
-    input.seekg(0, std::ios::end);
-    auto end_pos = input.tellg();
+    input_file.seekg(0, std::ios::end);
+    auto end_pos = input_file.tellg();
     if (end_pos < 0) {
         std::cerr << "Error: Can't determine file size" << std::endl;
         return 1;
     }
     file_length = static_cast<size_t>(end_pos);
-    input.seekg(0, std::ios::beg);
+    input_file.seekg(0, std::ios::beg);
 
     if (file_length == 0) {
         std::cerr << "Error: File is empty" << std::endl;
@@ -108,31 +122,47 @@ int loadFileIntoMemory() {
                   << MAX_WIRE_FILE_LENGTH << " bytes" << std::endl;
         return 1;
     }
-
-    file = new (std::nothrow) char[file_length];
-    if (!file) {
-        std::cerr << "Error: Can't allocate " << file_length << " bytes" << std::endl;
-        return 1;
-    }
-    input.read(file, static_cast<std::streamsize>(file_length));
-    if (static_cast<size_t>(input.gcount()) != file_length) {
-        std::cerr << "Error: Could not read entire file" << std::endl;
-        delete[] file;
-        file = nullptr;
-        return 1;
-    }
     return 0;
+}
+
+bool hashInputFile(uint8_t out[32]) {
+    Sha256::Ctx ctx;
+    Sha256::init(ctx);
+    std::vector<char> hash_buf(HASH_BUFFER_SIZE);
+
+    input_file.clear();
+    input_file.seekg(0, std::ios::beg);
+    size_t total = 0;
+    while (input_file.good()) {
+        input_file.read(hash_buf.data(), static_cast<std::streamsize>(hash_buf.size()));
+        std::streamsize got = input_file.gcount();
+        if (got > 0) {
+            Sha256::update(ctx, reinterpret_cast<const uint8_t*>(hash_buf.data()),
+                           static_cast<size_t>(got));
+            total += static_cast<size_t>(got);
+        }
+        if (got == 0) break;
+    }
+    if (total != file_length) {
+        std::cerr << "Error: Could not hash entire file" << std::endl;
+        return false;
+    }
+    Sha256::finish(ctx, out);
+
+    input_file.clear();
+    input_file.seekg(0, std::ios::beg);
+    return true;
 }
 
 // Build and broadcast the ANNOUNCE (retransmitted a few times, since a single
 // drop would strand every receiver and there is no RESEND for it).
-void sendAnnounce() {
+bool sendAnnounce() {
     std::random_device rd;
     session_id = static_cast<uint32_t>(rd());
 
     // Digest of the whole file; the receiver verifies against it after reassembly.
     uint8_t file_hash[32];
-    Sha256::hash(file, file_length, file_hash);
+    if (!hashInputFile(file_hash)) return false;
     if (verbose) std::cout << "Ok: sha256 " << Sha256::hex(file_hash) << std::endl;
 
     // Name the receiver saves under unless it was given an explicit output path.
@@ -162,6 +192,7 @@ void sendAnnounce() {
     if (verbose) {
         std::cout << "Ok: Sent information about new file with size " << file_length << std::endl;
     }
+    return true;
 }
 
 // Serve RESEND requests until ttl expires, re-announcing FINISH periodically.
@@ -238,16 +269,21 @@ size_t serveResends(size_t total_parts) {
 int run() {
     buffer = new char[2 * mtu];
 
-    if (loadFileIntoMemory() != 0) {
+    if (openInputFile() != 0) {
         delete[] buffer;
         buffer = nullptr;
         // The socket is main()'s to close (as on every other return path);
         // closing it here too made main()'s CLOSE_SOCKET a double-close.
         return 1;
     }
-    if (verbose) std::cout << "Ok: File successfully copied to RAM" << std::endl;
+    if (verbose) std::cout << "Ok: File opened for streaming" << std::endl;
 
-    sendAnnounce();
+    if (!sendAnnounce()) {
+        delete[] buffer;
+        buffer = nullptr;
+        input_file.close();
+        return 1;
+    }
 
     const std::string name = baseName(fileName);
     Progress::Reporter reporter;
@@ -277,9 +313,8 @@ int run() {
     if (verbose) std::cout << "Ok: Transfer session ended" << std::endl;
 
     delete[] buffer;
-    delete[] file;
     buffer = nullptr;
-    file   = nullptr;
+    input_file.close();
     return 0;
 }
 

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include <map>
 #include <random>
-#include <vector>
 
 using namespace std::chrono_literals;
 
@@ -47,8 +46,6 @@ std::string baseName(const std::string& path) {
 std::map<size_t, int64_t> sent_part;
 std::ifstream input_file;
 
-constexpr size_t HASH_BUFFER_SIZE = 1024 * 1024;
-
 bool readFileAt(size_t offset, char* out, size_t len) {
     input_file.clear();
     input_file.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
@@ -57,7 +54,7 @@ bool readFileAt(size_t offset, char* out, size_t len) {
     return static_cast<size_t>(input_file.gcount()) == len;
 }
 
-void sendPart(size_t part_index) {
+bool sendPart(size_t part_index) {
     size_t offset        = part_index * static_cast<size_t>(mtu);
     size_t packet_length = file_length - offset;
     if (packet_length > static_cast<size_t>(mtu)) packet_length = static_cast<size_t>(mtu);
@@ -66,19 +63,21 @@ void sendPart(size_t part_index) {
     Protocol::putU32(buffer + Protocol::HEADER_SIZE,     static_cast<uint32_t>(part_index));
     Protocol::putU32(buffer + Protocol::HEADER_SIZE + 4, static_cast<uint32_t>(packet_length));
     if (!readFileAt(offset, buffer + Protocol::TRANSFER_HEADER, packet_length)) {
-        std::cerr << "Warning: Failed to read part " << part_index << std::endl;
-        return;
+        std::cerr << "Error: Failed to read part " << part_index
+                  << " from " << fileName << std::endl;
+        return false;
     }
 
     auto sent = sendto(_socket, buffer, static_cast<int>(packet_length + Protocol::TRANSFER_HEADER), 0,
                        reinterpret_cast<sockaddr*>(&broadcast_address), sizeof(broadcast_address));
     if (sent < 0) {
         std::cerr << "Warning: Failed to send part " << part_index << std::endl;
-        return;
+        return true;
     }
     if (verbose) {
         std::cout << "Part " << part_index << " with size " << packet_length << " was sent" << std::endl;
     }
+    return true;
 }
 
 // Pause between packets to pace the transfer (0 = blast at full speed).
@@ -126,28 +125,12 @@ int openInputFile() {
 }
 
 bool hashInputFile(uint8_t out[32]) {
-    Sha256::Ctx ctx;
-    Sha256::init(ctx);
-    std::vector<char> hash_buf(HASH_BUFFER_SIZE);
-
     input_file.clear();
     input_file.seekg(0, std::ios::beg);
-    size_t total = 0;
-    while (input_file.good()) {
-        input_file.read(hash_buf.data(), static_cast<std::streamsize>(hash_buf.size()));
-        std::streamsize got = input_file.gcount();
-        if (got > 0) {
-            Sha256::update(ctx, reinterpret_cast<const uint8_t*>(hash_buf.data()),
-                           static_cast<size_t>(got));
-            total += static_cast<size_t>(got);
-        }
-        if (got == 0) break;
-    }
-    if (total != file_length) {
+    if (!Sha256::hashStream(input_file, file_length, out)) {
         std::cerr << "Error: Could not hash entire file" << std::endl;
         return false;
     }
-    Sha256::finish(ctx, out);
 
     input_file.clear();
     input_file.seekg(0, std::ios::beg);
@@ -197,9 +180,8 @@ bool sendAnnounce() {
 
 // Serve RESEND requests until ttl expires, re-announcing FINISH periodically.
 // Returns how many parts were re-sent on request.
-size_t serveResends(size_t total_parts) {
+bool serveResends(size_t total_parts, size_t& resent) {
     int64_t lastFinishSendTime = 0;
-    size_t  resent = 0;
 
     SOCKADDR_IN sender_address;
     memset(&sender_address, 0, sizeof(sender_address));
@@ -253,7 +235,7 @@ size_t serveResends(size_t total_parts) {
             if (verbose) {
                 std::cout << "Client requested part of file with index " << part << std::endl;
             }
-            sendPart(part);
+            if (!sendPart(part)) return false;
             ++resent;
         }
         // Re-announce completion at most once a second.
@@ -262,7 +244,7 @@ size_t serveResends(size_t total_parts) {
             sendFinish();
         }
     }
-    return resent;
+    return true;
 }
 
 // Returns a process exit code: 0 on success, non-zero on failure.
@@ -292,7 +274,13 @@ int run() {
     size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
     for (size_t part_index = 0; part_index < total_parts; ++part_index) {
         sent_part.insert({ part_index, 0 });
-        sendPart(part_index);
+        if (!sendPart(part_index)) {
+            reporter.finish();
+            delete[] buffer;
+            buffer = nullptr;
+            input_file.close();
+            return 1;
+        }
         reporter.update(std::min((part_index + 1) * static_cast<size_t>(mtu), file_length));
         pace();
     }
@@ -306,7 +294,13 @@ int run() {
 
     sendFinish();
 
-    size_t resent = serveResends(total_parts);
+    size_t resent = 0;
+    if (!serveResends(total_parts, resent)) {
+        delete[] buffer;
+        buffer = nullptr;
+        input_file.close();
+        return 1;
+    }
     if (resent > 0) {
         std::cout << "Re-sent " << resent << " part(s) on request" << std::endl;
     }

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -50,7 +50,7 @@ bool readFileAt(size_t offset, char* out, size_t len) {
     input_file.clear();
     input_file.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
     if (!input_file.good()) return false;
-    input_file.read(out, static_cast<std::streamsize>(len));
+    input_file.read(out, static_cast<std::streamsize>(len));  // Flawfinder: ignore (out sized to len by caller)
     return static_cast<size_t>(input_file.gcount()) == len;
 }
 

--- a/src/Sha256.hpp
+++ b/src/Sha256.hpp
@@ -131,7 +131,7 @@ inline bool hashStream(std::istream& in, size_t expected_len, uint8_t out[32],
     size_t total = 0;
 
     while (in.good()) {
-        in.read(buf.data(), static_cast<std::streamsize>(buf.size()));
+        in.read(buf.data(), static_cast<std::streamsize>(buf.size()));  // Flawfinder: ignore (buf sized to buffer_size)
         std::streamsize got = in.gcount();
         if (got > 0) {
             update(c, reinterpret_cast<const uint8_t*>(buf.data()), static_cast<size_t>(got));

--- a/src/Sha256.hpp
+++ b/src/Sha256.hpp
@@ -8,7 +8,9 @@
 #include <cstdint>
 #include <cstddef>
 #include <cstring>
+#include <istream>
 #include <string>
+#include <vector>
 
 namespace Sha256 {
 
@@ -118,6 +120,28 @@ inline void hash(const void* data, size_t len, uint8_t out[32]) {
     init(c);
     update(c, static_cast<const uint8_t*>(data), len);
     finish(c, out);
+}
+
+// Compute the SHA-256 digest of `expected_len` bytes read from `in`.
+inline bool hashStream(std::istream& in, size_t expected_len, uint8_t out[32],
+                       size_t buffer_size = 1024 * 1024) {
+    Ctx c;
+    init(c);
+    std::vector<char> buf(buffer_size);
+    size_t total = 0;
+
+    while (in.good()) {
+        in.read(buf.data(), static_cast<std::streamsize>(buf.size()));
+        std::streamsize got = in.gcount();
+        if (got > 0) {
+            update(c, reinterpret_cast<const uint8_t*>(buf.data()), static_cast<size_t>(got));
+            total += static_cast<size_t>(got);
+        }
+        if (got == 0) break;
+    }
+    if (total != expected_len) return false;
+    finish(c, out);
+    return true;
 }
 
 // 64-character lowercase hex of a 32-byte digest.

--- a/tests/corrupt_proxy.py
+++ b/tests/corrupt_proxy.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Corrupting UDP proxy for exercising the checksum-mismatch branch on loopback.
+"""
+Corrupting UDP proxy for exercising the checksum-mismatch branch on loopback.
 
 Like lossy_proxy.py this runs two unidirectional proxies in one process:
 

--- a/tests/corrupt_proxy.py
+++ b/tests/corrupt_proxy.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Corrupting UDP proxy for exercising the checksum-mismatch branch on loopback.
+
+Like lossy_proxy.py this runs two unidirectional proxies in one process:
+
+  * Forward direction:  listen-fwd  -> target-fwd  (sender -> receiver path)
+  * Backward direction: listen-back -> target-back (receiver -> sender path)
+
+Unlike the lossy proxy it drops nothing. Instead, exactly ONE TRANSFER packet
+in the forward direction has a single payload byte flipped; everything else is
+forwarded byte-for-byte. The part still validates (its header, index and length
+fields are untouched, so the receiver accepts and never re-requests it), but the
+reassembled file no longer matches the announced SHA-256 — driving the receiver
+into verifyAndWrite's "checksum mismatch — received file is corrupt" branch.
+
+Only the *first* data-bearing TRANSFER is corrupted, so the outcome is fully
+deterministic regardless of how the OS schedules the datagrams.
+"""
+
+import argparse
+import socket
+import sys
+import threading
+
+# Wire layout mirrored from src/Protocol.hpp (protocol v3):
+#   magic "FCST"(4) + version(1) + type(1) + session(4) = 10-byte header,
+#   then TRANSFER adds part(4) + length(4) before the payload.
+MAGIC = b"FCST"
+TYPE_TRANSFER = 2
+TRANSFER_HEADER = 18  # HEADER_SIZE(10) + part(4) + length(4); payload starts here
+
+
+def is_transfer(data):
+    return len(data) > TRANSFER_HEADER and data[:4] == MAGIC and data[5] == TYPE_TRANSFER
+
+
+def forward_clean(listen_port, target_host, target_port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", listen_port))
+    while True:
+        data, _ = sock.recvfrom(65536)
+        sock.sendto(data, (target_host, target_port))
+
+
+def forward_corrupt(listen_port, target_host, target_port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", listen_port))
+    corrupted = False
+    while True:
+        data, _ = sock.recvfrom(65536)
+        if not corrupted and is_transfer(data):
+            part = int.from_bytes(data[10:14], "big")
+            buf = bytearray(data)
+            buf[TRANSFER_HEADER] ^= 0xFF  # flip one payload byte, leave framing intact
+            data = bytes(buf)
+            corrupted = True
+            print(f"[corrupt] flipped one payload byte of TRANSFER part={part}",
+                  file=sys.stderr)
+        sock.sendto(data, (target_host, target_port))
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--listen-fwd",  type=int, required=True,
+                   help="Listen port for the sender->receiver direction")
+    p.add_argument("--target-fwd",  type=int, required=True,
+                   help="Where to forward sender->receiver traffic (corrupted once)")
+    p.add_argument("--listen-back", type=int, required=True,
+                   help="Listen port for the receiver->sender direction")
+    p.add_argument("--target-back", type=int, required=True,
+                   help="Where to forward receiver->sender traffic (untouched)")
+    args = p.parse_args()
+
+    threading.Thread(
+        target=forward_corrupt,
+        args=(args.listen_fwd, "127.0.0.1", args.target_fwd),
+        daemon=True,
+    ).start()
+    threading.Thread(
+        target=forward_clean,
+        args=(args.listen_back, "127.0.0.1", args.target_back),
+        daemon=True,
+    ).start()
+
+    threading.Event().wait()  # block forever; killed by parent
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/corrupt_proxy.py
+++ b/tests/corrupt_proxy.py
@@ -31,10 +31,12 @@ TRANSFER_HEADER = 18  # HEADER_SIZE(10) + part(4) + length(4); payload starts he
 
 
 def is_transfer(data):
+    """True if data is a data-bearing v3 TRANSFER packet (right magic and type)."""
     return len(data) > TRANSFER_HEADER and data[:4] == MAGIC and data[5] == TYPE_TRANSFER
 
 
 def forward_clean(listen_port, target_host, target_port):
+    """Forward every datagram from listen_port to the target byte-for-byte."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(("127.0.0.1", listen_port))
@@ -44,6 +46,7 @@ def forward_clean(listen_port, target_host, target_port):
 
 
 def forward_corrupt(listen_port, target_host, target_port):
+    """Forward datagrams, flipping one payload byte of the first TRANSFER seen."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(("127.0.0.1", listen_port))
@@ -62,6 +65,7 @@ def forward_corrupt(listen_port, target_host, target_port):
 
 
 def main():
+    """Parse CLI arguments and run the two forwarding threads until killed."""
     p = argparse.ArgumentParser()
     p.add_argument("--listen-fwd",  type=int, required=True,
                    help="Listen port for the sender->receiver direction")

--- a/tests/corrupt_proxy.py
+++ b/tests/corrupt_proxy.py
@@ -1,22 +1,20 @@
 #!/usr/bin/env python3
-"""
-Corrupting UDP proxy for exercising the checksum-mismatch branch on loopback.
-
-Like lossy_proxy.py this runs two unidirectional proxies in one process:
-
-  * Forward direction:  listen-fwd  -> target-fwd  (sender -> receiver path)
-  * Backward direction: listen-back -> target-back (receiver -> sender path)
-
-Unlike the lossy proxy it drops nothing. Instead, exactly ONE TRANSFER packet
-in the forward direction has a single payload byte flipped; everything else is
-forwarded byte-for-byte. The part still validates (its header, index and length
-fields are untouched, so the receiver accepts and never re-requests it), but the
-reassembled file no longer matches the announced SHA-256 — driving the receiver
-into verifyAndWrite's "checksum mismatch — received file is corrupt" branch.
-
-Only the *first* data-bearing TRANSFER is corrupted, so the outcome is fully
-deterministic regardless of how the OS schedules the datagrams.
-"""
+"""Corrupting UDP proxy for exercising the checksum-mismatch branch on loopback."""
+#
+# Like lossy_proxy.py this runs two unidirectional proxies in one process:
+#
+#   * Forward direction:  listen-fwd  -> target-fwd  (sender -> receiver path)
+#   * Backward direction: listen-back -> target-back (receiver -> sender path)
+#
+# Unlike the lossy proxy it drops nothing. Instead, exactly ONE TRANSFER packet
+# in the forward direction has a single payload byte flipped; everything else is
+# forwarded byte-for-byte. The part still validates (its header, index and length
+# fields are untouched, so the receiver accepts and never re-requests it), but the
+# reassembled file no longer matches the announced SHA-256 — driving the receiver
+# into verifyAndWrite's "checksum mismatch — received file is corrupt" branch.
+#
+# Only the first data-bearing TRANSFER is corrupted, so the outcome is fully
+# deterministic regardless of how the OS schedules the datagrams.
 
 import argparse
 import socket

--- a/tests/e2e_corrupt.sh
+++ b/tests/e2e_corrupt.sh
@@ -40,9 +40,9 @@ RECV_PID=""
 SEND_PID=""
 
 cleanup() {
-    [ -n "$RECV_PID"  ] && kill "$RECV_PID"  2>/dev/null || true
-    [ -n "$SEND_PID"  ] && kill "$SEND_PID"  2>/dev/null || true
-    [ -n "$PROXY_PID" ] && kill "$PROXY_PID" 2>/dev/null || true
+    if [ -n "$RECV_PID"  ]; then kill "$RECV_PID"  2>/dev/null || true; fi
+    if [ -n "$SEND_PID"  ]; then kill "$SEND_PID"  2>/dev/null || true; fi
+    if [ -n "$PROXY_PID" ]; then kill "$PROXY_PID" 2>/dev/null || true; fi
     rm -rf "$WORKDIR"
 }
 trap cleanup EXIT

--- a/tests/e2e_corrupt.sh
+++ b/tests/e2e_corrupt.sh
@@ -61,6 +61,11 @@ PROXY_BACK_IN=33604
 run_corrupt_test() {
     local label="$1"
     local extra_flag="$2"
+    # Optional receiver flag as an array so an empty value expands to no argument
+    # (a quoted "" would be passed as a stray empty positional). The +-guard keeps
+    # the expansion safe under `set -u` on bash 3.2 (macOS's default).
+    local -a extra=()
+    [ -n "$extra_flag" ] && extra=("$extra_flag")
 
     local dir="$WORKDIR/$label"
     mkdir -p "$dir"
@@ -86,7 +91,7 @@ run_corrupt_test() {
     # break a relative BINARY like build/filecast).
     "$BINARY" receive "$dir/out.bin" --to 127.0.0.1 \
               --bind-port "$RECV_BIND" --port "$PROXY_BACK_IN" \
-              --ttl 10 --delay-ms 0 $extra_flag > "$recv_log" 2>&1 &
+              --ttl 10 --delay-ms 0 ${extra[@]+"${extra[@]}"} > "$recv_log" 2>&1 &
     RECV_PID=$!
     sleep 1
 

--- a/tests/e2e_corrupt.sh
+++ b/tests/e2e_corrupt.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# Corrupting end-to-end test: run a transfer through a proxy that flips one
+# payload byte of a single TRANSFER packet, so every part is delivered (nothing
+# is re-requested) but the reassembled file fails its announced SHA-256. This
+# pins verifyAndWrite's checksum-mismatch cleanup — the branch that decides
+# between discardSnapshot() (--resume) and removePartFiles() (plain receive):
+#
+#   * the receiver must exit 2 and report the mismatch,
+#   * it must NOT write the corrupt bytes to the output file, and
+#   * it must leave NO .part / .part.idx behind in EITHER mode — a resumed run
+#     drops the poisoned snapshot too, so the next --resume starts clean instead
+#     of reloading the same corruption forever.
+#
+# Run via:
+#   ctest --test-dir build --output-on-failure
+#
+# Or directly:
+#   BINARY=build/filecast bash tests/e2e_corrupt.sh
+#
+set -euo pipefail
+
+BINARY="${BINARY:-./filecast}"
+PYTHON="${PYTHON:-python3}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ ! -x "$BINARY" ]; then
+    echo "Error: $BINARY not found or not executable. Build first." >&2
+    exit 1
+fi
+
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    echo "Error: $PYTHON not found in PATH; corrupt proxy needs Python 3." >&2
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d -t fb-e2e-corrupt.XXXXXX)"
+PROXY_PID=""
+RECV_PID=""
+SEND_PID=""
+
+cleanup() {
+    [ -n "$RECV_PID"  ] && kill "$RECV_PID"  2>/dev/null || true
+    [ -n "$SEND_PID"  ] && kill "$SEND_PID"  2>/dev/null || true
+    [ -n "$PROXY_PID" ] && kill "$PROXY_PID" 2>/dev/null || true
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# Topology (all on 127.0.0.1):
+#   sender bind   = 33602, sender   target -> 33603 (proxy fwd in, corrupts once)
+#   receiver bind = 33601, receiver target -> 33604 (proxy back in, clean)
+#   proxy fwd:  33603 -> 33601  (sender->receiver, one payload byte flipped)
+#   proxy back: 33604 -> 33602  (receiver->sender, untouched)
+RECV_BIND=33601
+SEND_BIND=33602
+PROXY_FWD_IN=33603
+PROXY_BACK_IN=33604
+
+# Args: label, extra receiver flag (e.g. "--resume" or "")
+run_corrupt_test() {
+    local label="$1"
+    local extra_flag="$2"
+
+    local dir="$WORKDIR/$label"
+    mkdir -p "$dir"
+    local src="$dir/src.bin"
+    local recv_log="$dir/recv.log"
+    local send_log="$dir/send.log"
+    local proxy_log="$dir/proxy.log"
+
+    echo "==> [$label] generating 50 KiB file (one payload byte will be corrupted)"
+    dd if=/dev/urandom of="$src" bs=1024 count=50 status=none
+
+    echo "==> [$label] starting corrupt proxy"
+    "$PYTHON" "$SCRIPT_DIR/corrupt_proxy.py" \
+        --listen-fwd  "$PROXY_FWD_IN"  --target-fwd  "$RECV_BIND" \
+        --listen-back "$PROXY_BACK_IN" --target-back "$SEND_BIND" \
+        > "$proxy_log" 2>&1 &
+    PROXY_PID=$!
+    sleep 0.5  # let the proxy bind both sockets
+
+    echo "==> [$label] starting receiver (${extra_flag:-plain})"
+    # The .part/.part.idx snapshot lands next to the output file, so an absolute
+    # output path keeps every artifact inside $dir without cd-ing (which would
+    # break a relative BINARY like build/filecast).
+    "$BINARY" receive "$dir/out.bin" --to 127.0.0.1 \
+              --bind-port "$RECV_BIND" --port "$PROXY_BACK_IN" \
+              --ttl 10 --delay-ms 0 $extra_flag > "$recv_log" 2>&1 &
+    RECV_PID=$!
+    sleep 1
+
+    echo "==> [$label] starting sender"
+    "$BINARY" send "$src" --to 127.0.0.1 \
+              --bind-port "$SEND_BIND" --port "$PROXY_FWD_IN" \
+              --ttl 5 --delay-ms 0 > "$send_log" 2>&1 &
+    SEND_PID=$!
+
+    # The receiver reassembles every part, fails the whole-file checksum, and
+    # exits 2. Capture that exit code rather than letting `wait` abort the script.
+    local rc=0
+    wait "$RECV_PID" || rc=$?
+    RECV_PID=""
+
+    kill "$SEND_PID"  2>/dev/null || true; wait "$SEND_PID"  2>/dev/null || true; SEND_PID=""
+    kill "$PROXY_PID" 2>/dev/null || true; wait "$PROXY_PID" 2>/dev/null || true; PROXY_PID=""
+
+    if [ "$rc" -ne 2 ]; then
+        echo "FAIL: [$label] expected receiver exit 2, got $rc"
+        echo "--- receiver log (tail):"; tail -20 "$recv_log"
+        echo "--- proxy log (tail):";    tail -20 "$proxy_log"
+        return 1
+    fi
+    if ! grep -q "checksum mismatch" "$recv_log"; then
+        echo "FAIL: [$label] receiver did not report a checksum mismatch"
+        echo "--- receiver log (tail):"; tail -20 "$recv_log"
+        echo "--- proxy log (tail):";    tail -20 "$proxy_log"
+        return 1
+    fi
+    # Sanity: if the proxy never corrupted a packet the file would have verified,
+    # so this test would pass for the wrong reason. Require proof it did its job.
+    if ! grep -q "flipped one payload byte" "$proxy_log"; then
+        echo "FAIL: [$label] proxy never corrupted a TRANSFER packet"
+        echo "--- proxy log (tail):"; tail -20 "$proxy_log"
+        return 1
+    fi
+    if [ -f "$dir/out.bin" ]; then
+        echo "FAIL: [$label] corrupt data was written to the output file"
+        return 1
+    fi
+    if [ -f "$dir/out.bin.part" ] || [ -f "$dir/out.bin.part.idx" ]; then
+        echo "FAIL: [$label] left a poisoned snapshot behind:"
+        ls "$dir"
+        return 1
+    fi
+
+    echo "PASS: [$label] checksum mismatch rejected (exit 2, no output, no snapshot)"
+}
+
+# Plain receive: mismatch -> removePartFiles() wipes the .part storage.
+run_corrupt_test "corrupt-plain"  ""
+# Resumable receive: mismatch -> discardSnapshot() drops the poisoned snapshot
+# too, so a later --resume does not reload the same corruption forever.
+run_corrupt_test "corrupt-resume" "--resume"
+
+echo
+echo "All corrupt E2E tests passed."


### PR DESCRIPTION
## Summary

This moves filecast's transfer storage off the heap while keeping the existing v3 wire format unchanged.

- Sender now opens the input file, hashes it incrementally, and reads packet payloads by offset instead of loading the whole file into RAM.
- Receiver now writes incoming chunks directly into an on-disk .part file, verifies SHA-256 from disk, and atomically finalizes that file.
- Resume now keeps the .part payload on disk and stores only the received-part bitmap in .part.idx.
- README and protocol docs now describe disk-backed storage and the remaining v3 4-byte wire-size limit.

## Impact

Memory use is now bounded by packet/hash buffers rather than file size. The maximum file size is still capped by the v3 protocol's 4-byte file-size field; lifting that requires a separate protocol bump.

## Validation

- rtk cmake --build build
- rtk ctest --test-dir build --output-on-failure