### PR TITLE
Reject control/NUL bytes in sanitizeName

### DIFF
--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -147,14 +147,28 @@ inline bool isReservedDeviceName(const std::string& name) {
     return false;
 }
 
+// Does the name contain a control byte (< 0x20, incl. NUL) or DEL (0x7f)?
+// Two distinct attacks ride in via such bytes from a hostile announcement:
+//   * an embedded NUL truncates the C string we hand to open()/rename(), so the
+//     file lands on disk under a shorter name than the one we printed (and the
+//     ".part" suffix silently disappears);
+//   * an ANSI escape (ESC, 0x1b) smuggled into the name hijacks the receiver's
+//     terminal when we echo "Receiving <name>" / "Received <name>".
+inline bool hasControlChar(const std::string& name) {
+    return std::any_of(name.begin(), name.end(), [](unsigned char c) {
+        return c < 0x20 || c == 0x7f;
+    });
+}
+
 // Reduce a sender-supplied name to a safe base name in the working directory:
-// strip directories, and reject traversal, ':' (Windows drive-relative / ADS)
-// and reserved device names by falling back to "file.out".
+// strip directories, and reject traversal, ':' (Windows drive-relative / ADS),
+// control/NUL bytes and reserved device names by falling back to "file.out".
 inline std::string sanitizeName(const std::string& raw) {
     size_t slash = raw.find_last_of("/\\");
     std::string name = (slash == std::string::npos) ? raw : raw.substr(slash + 1);
     if (name.empty() || name == "." || name == "..") return "file.out";
     if (name.find(':') != std::string::npos) return "file.out";
+    if (hasControlChar(name)) return "file.out";
     if (isReservedDeviceName(name)) return "file.out";
     return name;
 }

--- a/tests/Tests.cpp
+++ b/tests/Tests.cpp
@@ -156,9 +156,31 @@ TEST(Protocol, SanitizeNameRejectsDangerous) {
     EXPECT_EQ(Protocol::sanitizeName("LPT9"), "file.out");
 }
 
+TEST(Protocol, SanitizeNameRejectsControlBytes) {
+    using std::string;
+    // Embedded NUL: without this guard the name passes every other check but the
+    // on-disk path truncates at the NUL ("evil"), diverging from what we print.
+    EXPECT_EQ(Protocol::sanitizeName(string("evil\0.txt", 9)), "file.out");
+    EXPECT_EQ(Protocol::sanitizeName(string("\0", 1)), "file.out");
+    // ANSI escape / DEL / other control bytes would inject into the receiver's
+    // terminal when the name is echoed; reject them all.
+    EXPECT_EQ(Protocol::sanitizeName("\033[2J\033[Hpwned"), "file.out");  // ESC (0x1b)
+    EXPECT_EQ(Protocol::sanitizeName("bell\a.txt"), "file.out");          // BEL (0x07)
+    EXPECT_EQ(Protocol::sanitizeName("line\nbreak.txt"), "file.out");     // LF  (0x0a)
+    EXPECT_EQ(Protocol::sanitizeName("tab\tchar.txt"), "file.out");       // TAB (0x09)
+    EXPECT_EQ(Protocol::sanitizeName(string("del\x7f.txt", 8)), "file.out"); // DEL (0x7f)
+    // A control byte living only in a stripped directory component must not
+    // condemn an otherwise-clean base name.
+    EXPECT_EQ(Protocol::sanitizeName(string("dir\n/clean.txt", 14)), "clean.txt");
+}
+
 TEST(Protocol, SanitizeNameAllowsNormalNames) {
     EXPECT_EQ(Protocol::sanitizeName("console.log"), "console.log");  // not a device
     EXPECT_EQ(Protocol::sanitizeName("com10.bin"), "com10.bin");      // COM10 is not reserved
+    // Bytes >= 0x20 stay put — spaces, punctuation and high/UTF-8 bytes are fine.
+    EXPECT_EQ(Protocol::sanitizeName("my report (final).pdf"), "my report (final).pdf");
+    EXPECT_EQ(Protocol::sanitizeName("\xD1\x84\xD0\xB0\xD0\xB9\xD0\xBB.txt"),
+              "\xD1\x84\xD0\xB0\xD0\xB9\xD0\xBB.txt");               // UTF-8 "файл.txt"
 }
 
 TEST(Protocol, TotalPartsBoundaries) {


### PR DESCRIPTION
## Problem

`Protocol::sanitizeName` hardens against a hostile file name (it strips directories and rejects `..`, `:`/ADS, and reserved Windows device names), but it lets **NUL and ASCII control bytes** through. The name arrives from an ANNOUNCE packet as `std::string(buf + ANNOUNCE_FIXED, name_len)` and may contain arbitrary bytes — and per the README threat model, "any host on the LAN can announce a transfer".

Two attacks slip past the sanitizer:

1. **Terminal injection.** A name like `\033[2J\033[Hpwned` is returned unchanged and printed to the receiver's console (`Receiving <name>` / `Received <name>`), letting an unauthenticated sender on the LAN inject ANSI escape sequences into the victim's terminal.
2. **NUL truncation.** A name like `evil\0.txt` (no slash) passes the filter, but `part_path.c_str()` / the rename target truncate at the NUL down to `evil` — the file lands on disk under a different name than the one displayed, and the `.part` suffix is lost.

Impact/likelihood: **low** — requires a hostile or corrupt host on the trusted LAN. Memory safety is not affected.

## Fix

Add a `hasControlChar` helper; `sanitizeName` now rejects a name (falling back to `file.out`) if it contains any byte `< 0x20` (including NUL) or `0x7f` (DEL), the same way the other dangerous cases are handled. The check runs on the already-extracted base name, so a control byte living only in a stripped directory component does not condemn an otherwise-clean file name.

## Tests

New test `Protocol.SanitizeNameRejectsControlBytes` covers: NUL truncation, ESC/BEL/LF/TAB/DEL control bytes, and a control byte confined to a stripped directory. `SanitizeNameAllowsNormalNames` is extended to confirm ordinary bytes (spaces, punctuation, UTF-8 "файл.txt") are left untouched.

Local run: `35 tests from 4 test suites — PASSED`.
