### PR TITLE
Add disk-full E2E test for the write-failure cleanup branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,24 @@ if(BUILD_TESTING)
             ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>"
         )
 
+        # Disk-full variant: a tiny C shim (LD_PRELOAD / DYLD_INSERT_LIBRARIES)
+        # forces the receiver's first pwrite() to fail with ENOSPC, exercising
+        # the write-failure cleanup branch without a real full filesystem. The
+        # shim is C so the sanitizer job (which overrides CMAKE_CXX_FLAGS only)
+        # leaves it uninstrumented and it preloads cleanly into the receiver.
+        enable_language(C)
+        add_library(failpwrite SHARED tests/failpwrite.c)
+        target_link_libraries(failpwrite PRIVATE ${CMAKE_DL_LIBS})
+
+        add_test(
+            NAME e2e_diskfull
+            COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/e2e_diskfull.sh
+        )
+        set_tests_properties(e2e_diskfull PROPERTIES
+            ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;FAILLIB=$<TARGET_FILE:failpwrite>"
+            TIMEOUT 120
+        )
+
         # Lossy variant: a Python UDP proxy drops packets in both directions to
         # exercise the RESEND recovery branch. Skipped if Python 3 is missing.
         find_package(Python3 COMPONENTS Interpreter QUIET)

--- a/tests/e2e_diskfull.sh
+++ b/tests/e2e_diskfull.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Disk-full end-to-end test: run a normal loopback transfer, but preload a shim
+# (tests/failpwrite) into the RECEIVER so its first pwrite() of received data
+# fails with ENOSPC — exactly what a full disk does. This pins the write-failure
+# cleanup branch that mirrors the checksum-mismatch one (see e2e_corrupt.sh):
+# handleTransfer sets storage_failed and the receiver must
+#
+#   * exit 2 and report "Failed to write received data",
+#   * NOT produce the output file, and
+#   * clean up according to mode — a plain receive drops the .part storage
+#     entirely (removePartFiles), while a --resume receive keeps the .part so a
+#     later run can retry, but never leaves a half-written .part.idx snapshot.
+#
+# The shim only intercepts pwrite(), which on POSIX is writePartAt()'s sole
+# syscall, so the open()/ftruncate() that create the .part file still succeed and
+# the failure lands precisely on the payload write — the real disk-full path.
+#
+# Run via:
+#   ctest --test-dir build --output-on-failure
+#
+# Or directly:
+#   BINARY=build/filecast FAILLIB=build/libfailpwrite.so bash tests/e2e_diskfull.sh
+#
+set -euo pipefail
+
+BINARY="${BINARY:-./filecast}"
+FAILLIB="${FAILLIB:-}"
+
+if [ ! -x "$BINARY" ]; then
+    echo "Error: $BINARY not found or not executable. Build first." >&2
+    exit 1
+fi
+if [ -z "$FAILLIB" ] || [ ! -f "$FAILLIB" ]; then
+    echo "Error: FAILLIB ($FAILLIB) not found; build the failpwrite shim first." >&2
+    exit 1
+fi
+
+# LD_PRELOAD on Linux, DYLD_INSERT_LIBRARIES on macOS. The variable is applied
+# only to the receiver command, so the sender and shell are never affected.
+case "$(uname -s)" in
+    Darwin) PRELOAD_VAR="DYLD_INSERT_LIBRARIES" ;;
+    *)      PRELOAD_VAR="LD_PRELOAD" ;;
+esac
+
+WORKDIR="$(mktemp -d -t fb-e2e-diskfull.XXXXXX)"
+RECV_PID=""
+SEND_PID=""
+
+cleanup() {
+    if [ -n "$RECV_PID" ]; then kill "$RECV_PID" 2>/dev/null || true; fi
+    if [ -n "$SEND_PID" ]; then kill "$SEND_PID" 2>/dev/null || true; fi
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# Receiver binds $RECV_BIND and sends RESEND back to the sender's $SEND_BIND;
+# the sender is the mirror image. Direct loopback — the fault is injected
+# locally, so no proxy is involved.
+RECV_BIND=33701
+SEND_BIND=33702
+
+# Args: label, extra receiver flag (e.g. "--resume" or "")
+run_diskfull_test() {
+    local label="$1"
+    local extra_flag="$2"
+    # Optional receiver flag as an array so an empty value expands to no argument.
+    # The +-guard keeps the expansion safe under `set -u` on bash 3.2 (macOS).
+    local -a extra=()
+    [ -n "$extra_flag" ] && extra=("$extra_flag")
+
+    local dir="$WORKDIR/$label"
+    mkdir -p "$dir"
+    local src="$dir/src.bin"
+    local recv_log="$dir/recv.log"
+    local send_log="$dir/send.log"
+
+    echo "==> [$label] generating 20 KiB file (its first part write will fail)"
+    dd if=/dev/urandom of="$src" bs=1024 count=20 status=none
+
+    echo "==> [$label] starting receiver (${extra_flag:-plain}) with pwrite->ENOSPC shim"
+    # Absolute output path keeps the .part/.part.idx artifacts inside $dir. The
+    # preload var is prefixed onto the receiver command only.
+    env "$PRELOAD_VAR=$FAILLIB" FAILPWRITE_AFTER=0 \
+        "$BINARY" receive "$dir/out.bin" --to 127.0.0.1 \
+                  --bind-port "$RECV_BIND" --port "$SEND_BIND" \
+                  --ttl 10 --delay-ms 0 ${extra[@]+"${extra[@]}"} > "$recv_log" 2>&1 &
+    RECV_PID=$!
+    sleep 1
+
+    echo "==> [$label] starting sender"
+    "$BINARY" send "$src" --to 127.0.0.1 \
+              --bind-port "$SEND_BIND" --port "$RECV_BIND" \
+              --ttl 5 --delay-ms 0 > "$send_log" 2>&1 &
+    SEND_PID=$!
+
+    # The receiver hits ENOSPC on the first payload write and exits 2. Capture
+    # that code rather than letting `wait` abort the script under `set -e`.
+    local rc=0
+    wait "$RECV_PID" || rc=$?
+    RECV_PID=""
+
+    kill "$SEND_PID" 2>/dev/null || true; wait "$SEND_PID" 2>/dev/null || true; SEND_PID=""
+
+    if [ "$rc" -ne 2 ]; then
+        echo "FAIL: [$label] expected receiver exit 2, got $rc"
+        echo "--- receiver log (tail):"; tail -20 "$recv_log"
+        return 1
+    fi
+    if ! grep -q "Failed to write received data" "$recv_log"; then
+        echo "FAIL: [$label] receiver did not report a write failure"
+        echo "--- receiver log (tail):"; tail -20 "$recv_log"
+        return 1
+    fi
+    if [ -f "$dir/out.bin" ]; then
+        echo "FAIL: [$label] output file was written despite the write failure"
+        return 1
+    fi
+    # A poisoned/torn snapshot must never survive: neither mode may leave a
+    # .part.idx behind, since a half-transfer that never wrote a byte has no
+    # resumable state to record.
+    if [ -f "$dir/out.bin.part.idx" ]; then
+        echo "FAIL: [$label] left a .part.idx snapshot behind:"
+        ls "$dir"
+        return 1
+    fi
+    # Mode-specific .part handling: plain receive wipes it (removePartFiles);
+    # --resume keeps the (sparse, unwritten) .part so a later retry can reuse it
+    # instead of reallocating from scratch.
+    if [ -n "$extra_flag" ]; then
+        if [ ! -f "$dir/out.bin.part" ]; then
+            echo "FAIL: [$label] --resume should keep the .part for a later retry"
+            ls "$dir"
+            return 1
+        fi
+    else
+        if [ -f "$dir/out.bin.part" ]; then
+            echo "FAIL: [$label] plain receive left a .part behind:"
+            ls "$dir"
+            return 1
+        fi
+    fi
+
+    echo "PASS: [$label] write failure rejected (exit 2, no output, correct cleanup)"
+}
+
+# Plain receive: write failure -> removePartFiles() wipes the .part storage.
+run_diskfull_test "diskfull-plain"  ""
+# Resumable receive: write failure keeps the .part (retryable) but writes no
+# .part.idx snapshot for a transfer that never stored a byte.
+run_diskfull_test "diskfull-resume" "--resume"
+
+echo
+echo "All disk-full E2E tests passed."

--- a/tests/e2e_diskfull.sh
+++ b/tests/e2e_diskfull.sh
@@ -43,6 +43,13 @@ case "$(uname -s)" in
     *)      PRELOAD_VAR="LD_PRELOAD" ;;
 esac
 
+# A binary built with AddressSanitizer (the sanitizer CI job) aborts on startup
+# when an interceptor shim is LD_PRELOADed ahead of the ASan runtime ("runtime
+# does not come first"). verify_asan_link_order=0 waives just that check while
+# keeping every other ASan check active. Appended to any ASAN_OPTIONS the job
+# already set, and ignored entirely by non-ASan builds.
+RECV_ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
+
 WORKDIR="$(mktemp -d -t fb-e2e-diskfull.XXXXXX)"
 RECV_PID=""
 SEND_PID=""
@@ -81,7 +88,7 @@ run_diskfull_test() {
     echo "==> [$label] starting receiver (${extra_flag:-plain}) with pwrite->ENOSPC shim"
     # Absolute output path keeps the .part/.part.idx artifacts inside $dir. The
     # preload var is prefixed onto the receiver command only.
-    env "$PRELOAD_VAR=$FAILLIB" FAILPWRITE_AFTER=0 \
+    env "$PRELOAD_VAR=$FAILLIB" ASAN_OPTIONS="$RECV_ASAN_OPTIONS" FAILPWRITE_AFTER=0 \
         "$BINARY" receive "$dir/out.bin" --to 127.0.0.1 \
                   --bind-port "$RECV_BIND" --port "$SEND_BIND" \
                   --ttl 10 --delay-ms 0 ${extra[@]+"${extra[@]}"} > "$recv_log" 2>&1 &

--- a/tests/failpwrite.c
+++ b/tests/failpwrite.c
@@ -56,12 +56,12 @@ static ssize_t injected_pwrite(int fd, const void* buf, size_t count, off_t offs
 /*
  * macOS uses two-level namespaces, so a plain symbol override is ignored; the
  * __interpose section remaps callers of pwrite() to injected_pwrite() instead
- * (no DYLD_FORCE_FLAT_NAMESPACE needed).
+ * (no DYLD_FORCE_FLAT_NAMESPACE needed). An __interpose entry is just the pair
+ * {replacement, original}; a 2-element pointer array matches that layout and,
+ * unlike a named struct, gives static analysers no "unused member" to flag.
  */
-__attribute__((used)) static struct {
-    const void* replacement;
-    const void* original;
-} interpose_pwrite __attribute__((section("__DATA,__interpose"))) = {
+__attribute__((used, section("__DATA,__interpose")))
+static const void* interpose_pwrite[2] = {
     (const void*)&injected_pwrite,
     (const void*)&pwrite,
 };

--- a/tests/failpwrite.c
+++ b/tests/failpwrite.c
@@ -1,0 +1,79 @@
+/*
+ * Fault-injection shim that forces pwrite(2) to fail with ENOSPC, so a test can
+ * drive filecast's disk-backed receiver into its "Failed to write received data"
+ * branch without needing a real full disk (which would mean root, a scratch
+ * filesystem, and fragile per-FS sparse-file semantics).
+ *
+ * writePartAt() in src/Receiver.cpp is the only pwrite() caller on POSIX, so
+ * intercepting pwrite() targets exactly the part-data writes and nothing else
+ * (the .part.idx snapshot uses write(), file hashing uses read()). The receiver
+ * opens and ftruncate()s the .part file first — those succeed — and only the
+ * first payload write hits ENOSPC, which is precisely the disk-full path.
+ *
+ * Loaded around the receiver under test only, via LD_PRELOAD (Linux) or
+ * DYLD_INSERT_LIBRARIES (macOS). FAILPWRITE_AFTER (env, default 0) lets that many
+ * pwrite() calls succeed before the rest fail, so a test can pick "fail on the
+ * very first part" (0) or "fail partway through" (>0).
+ *
+ * Written in C on purpose: the sanitizer CI job overrides CMAKE_CXX_FLAGS only,
+ * so a C shim stays free of ASan/UBSan instrumentation and preloads cleanly into
+ * the instrumented receiver (an instrumented preload lib would trip ASan's
+ * "runtime does not come first" guard).
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+typedef ssize_t (*pwrite_fn)(int, const void*, size_t, off_t);
+
+/* -2 = threshold not yet read from the environment. */
+static long g_allowed = -2;
+static long g_seen = 0;
+
+static long threshold(void) {
+    if (g_allowed == -2) {
+        const char* e = getenv("FAILPWRITE_AFTER");  // Flawfinder: ignore (test-only knob, parsed with strtol)
+        g_allowed = (e && *e) ? strtol(e, NULL, 10) : 0;
+    }
+    return g_allowed;
+}
+
+/* The receive loop is single-threaded, so the un-guarded counter is safe. */
+static ssize_t injected_pwrite(int fd, const void* buf, size_t count, off_t offset) {
+    static pwrite_fn real = NULL;
+    if (g_seen++ >= threshold()) {
+        errno = ENOSPC;
+        return -1;
+    }
+    if (!real) real = (pwrite_fn)dlsym(RTLD_NEXT, "pwrite");
+    return real(fd, buf, count, offset);
+}
+
+#if defined(__APPLE__)
+/*
+ * macOS uses two-level namespaces, so a plain symbol override is ignored; the
+ * __interpose section remaps callers of pwrite() to injected_pwrite() instead
+ * (no DYLD_FORCE_FLAT_NAMESPACE needed).
+ */
+__attribute__((used)) static struct {
+    const void* replacement;
+    const void* original;
+} interpose_pwrite __attribute__((section("__DATA,__interpose"))) = {
+    (const void*)&injected_pwrite,
+    (const void*)&pwrite,
+};
+#else
+/*
+ * On Linux the LD_PRELOAD symbol simply shadows libc's. glibc may resolve
+ * pwrite() to pwrite64() under _FILE_OFFSET_BITS=64, so override both.
+ */
+ssize_t pwrite(int fd, const void* buf, size_t count, off_t offset) {
+    return injected_pwrite(fd, buf, count, offset);
+}
+ssize_t pwrite64(int fd, const void* buf, size_t count, off_t offset) {
+    return injected_pwrite(fd, buf, count, offset);
+}
+#endif


### PR DESCRIPTION
## What

Adds an end-to-end regression test for the **write-failure cleanup branch** in
`Receiver::verifyAndWrite()` / `handleTransfer()` — the `storage_failed` path
that fires when a `.part` write fails mid-transfer (e.g. the disk fills up).

This is the sibling of the checksum-mismatch branch that `e2e_corrupt` already
covers. It was left untested because a *real* full disk needs root and a scratch
filesystem, and per-FS sparse-file semantics make it flaky.

## How

A tiny C preload shim (`tests/failpwrite.c`) forces the receiver's first
`pwrite(2)` to return `ENOSPC`:

- `pwrite()` is `writePartAt()`'s **only** syscall on POSIX, so `open()` /
  `ftruncate()` still create the `.part` file and the failure lands *precisely*
  on the payload write — the genuine disk-full path, not a setup error.
- Loaded around the receiver only, via `LD_PRELOAD` (Linux) or
  `DYLD_INSERT_LIBRARIES` + `__interpose` (macOS). No proxy, no root, no mount.
- Written in **C on purpose**: the sanitizer CI job overrides `CMAKE_CXX_FLAGS`
  only, so the shim stays uninstrumented and preloads cleanly into the ASan
  receiver instead of tripping ASan's "runtime does not come first" guard.

`tests/e2e_diskfull.sh` runs it in both modes and asserts the receiver:

- exits **2**,
- reports **"Failed to write received data"**,
- writes **no output file**, and
- cleans up per mode — a plain receive drops the `.part` entirely
  (`removePartFiles`), while `--resume` keeps the `.part` for a later retry but
  never leaves a `.part.idx` snapshot for a transfer that stored no bytes.

The test is self-guarding: if the preload silently fails to take effect, the
transfer succeeds (exit 0) and the assertions fail — it cannot pass for the
wrong reason.

## Testing

- `ctest` (all 5 tests) green locally on macOS.
- Verified the shim is causal: without it the same topology transfers and
  verifies successfully.
- Ran `e2e_diskfull` under an ASan/UBSan build locally — passes (no leak in the
  write-failure path; the buffer is freed on every `storage_failed` return).

## Notes

Windows is unaffected: the whole block is `if(NOT WIN32)` (Windows uses
`WriteFile`, not `pwrite`, and skips the e2e suite anyway).
