### PR TITLE
Don't delete cwd .part files when receive times out before ANNOUNCE

### DIFF
--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -222,6 +222,10 @@ bool hashPartFile(uint8_t out[32]) {
 }
 
 void removePartFiles() {
+    // part_path is empty until an ANNOUNCE opens the part file. Bail out then:
+    // with no ANNOUNCE fileName is still "", so removing fileName+".part" would
+    // delete a bare ".part"/".part.idx" in the cwd — another transfer's files.
+    if (part_path.empty()) return;
     closePartFile(false);
     std::remove(snapshotPartPath().c_str());
     std::remove((fileName + ".part.idx").c_str());

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -222,9 +222,9 @@ bool hashPartFile(uint8_t out[32]) {
 }
 
 void removePartFiles() {
-    // part_path is empty until an ANNOUNCE opens the part file. Bail out then:
-    // with no ANNOUNCE fileName is still "", so removing fileName+".part" would
-    // delete a bare ".part"/".part.idx" in the cwd — another transfer's files.
+    // part_path is set as soon as openPartFile() runs, which only happens while
+    // handling an ANNOUNCE. Empty means no part file opened this run — fileName
+    // is still "", so removing fileName+".part" would nuke a bare ".part" in cwd.
     if (part_path.empty()) return;
     closePartFile(false);
     std::remove(snapshotPartPath().c_str());

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -317,5 +317,35 @@ run_resume_test() {
 }
 run_resume_test
 
+# Timeout before ANNOUNCE: a `receive` with no output path that times out before
+# any sender appears must not touch the cwd. Previously fileName was still empty
+# at that point, so the cleanup removed a bare ".part"/".part.idx" — deleting an
+# unrelated transfer's files. Plant decoys named exactly that and assert they
+# survive (exit 2, no output produced).
+run_timeout_no_sender_test() {
+    local dir="$WORKDIR/timeout-no-sender"
+    mkdir -p "$dir"
+    echo "unrelated part data" > "$dir/.part"
+    echo "unrelated idx data"  > "$dir/.part.idx"
+
+    echo "==> [no-sender] receive with no output path, no sender, short ttl"
+    local rc=0
+    ( cd "$dir" && exec "$BINARY" receive --to 127.0.0.1 \
+          --bind-port 33413 --port 33414 --ttl 1 --delay-ms 0 > recv.log 2>&1 ) || rc=$?
+
+    if [ "$rc" -ne 2 ]; then
+        echo "FAIL: [no-sender] expected receiver exit 2, got $rc"
+        tail -5 "$dir/recv.log"
+        return 1
+    fi
+    if [ ! -f "$dir/.part" ] || [ ! -f "$dir/.part.idx" ]; then
+        echo "FAIL: [no-sender] cwd .part/.part.idx were deleted by the timeout cleanup"
+        ls -a "$dir"
+        return 1
+    fi
+    echo "PASS: [no-sender] timeout before ANNOUNCE left the cwd untouched"
+}
+run_timeout_no_sender_test
+
 echo
 echo "All E2E tests passed."


### PR DESCRIPTION
## Problem

A `receive` with no output path whose `--ttl` expires **before** the first `ANNOUNCE` arrives (the sender never showed up, crashed, or the network dropped) deletes unrelated files from the current directory.

Path: `run()` → `onTimeout()` → `saveSnapshot()` returns `false` (no `storage_ready`/`have_session`) → `removePartFiles()`.

At that point `fileName` is still empty (`""`), because it is only populated in `handleAnnounce()`. So `removePartFiles()` runs:

```cpp
std::remove((fileName + ".part").c_str());      // -> std::remove(".part")
std::remove((fileName + ".part.idx").c_str());  // -> std::remove(".part.idx")
```

— i.e. it removes files named `.part` and `.part.idx` from the **cwd**, which belong to some other transfer, not this one.

Reproduced on `1288ef4`: both files disappear after `receive --ttl 1` with no sender.

## Root cause

`removePartFiles()` is called unconditionally, even when this run never created a part file. With an empty `fileName` the paths collapse to bare names in the current directory.

## Fix

Guard `removePartFiles()` on `part_path`. That global string is set only inside `openPartFile()`, which is reached exclusively after an `ANNOUNCE`. An empty `part_path` ⟺ no part file was opened this run ⟺ nothing of ours to remove → early `return`.

This is targeted and covers every `removePartFiles()` call site: the paths after a transfer has begun (`onRecoveryTimeout`, `verifyAndWrite`, `checkParts`) are unaffected — `part_path` is already set there.

## Test

Added an e2e regression `run_timeout_no_sender_test`: it plants "foreign" `.part`/`.part.idx` in the cwd, runs `receive` with no sender and a short ttl, and asserts that after exit (code 2) both files are still present.

Verified manually: the test **fails** on the pre-fix binary (files get deleted) and **passes** after the fix. The full `ctest` suite (unit + e2e) is green.