### PR TITLE
Propagate durable flush/close errors from closePartFile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,22 @@ if(BUILD_TESTING)
             TIMEOUT 120
         )
 
+        # Durable-sync-failure variant: a sibling C shim forces the receiver's
+        # fsync() to fail with EIO, so a completed transfer's durable sync fails
+        # while the page-cache re-read still passes — pinning that verifyAndWrite
+        # never reports "sha256 verified" for un-synced data. Linux only (the
+        # e2e_syncfail.sh script self-skips elsewhere; see its header).
+        add_library(failsync SHARED tests/failsync.c)
+
+        add_test(
+            NAME e2e_syncfail
+            COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/e2e_syncfail.sh
+        )
+        set_tests_properties(e2e_syncfail PROPERTIES
+            ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;FAILLIB=$<TARGET_FILE:failsync>"
+            TIMEOUT 120
+        )
+
         # Lossy variant: a Python UDP proxy drops packets in both directions to
         # exercise the RESEND recovery branch. Skipped if Python 3 is missing.
         find_package(Python3 COMPONENTS Interpreter QUIET)

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -119,17 +119,24 @@ std::string snapshotPartPath() {
     return fileName + ".part";
 }
 
-void closePartFile(bool flush) {
+// Close the part file, optionally flushing to stable storage first. Returns true
+// only when the requested flush AND the close both succeed — a failed durable
+// sync means the bytes may never reach disk. The handle is always released.
+bool closePartFile(bool flush) {
     #if defined(_WIN32) || defined(_WIN64)
-    if (part_handle == INVALID_HANDLE_VALUE) return;
-    if (flush) FlushFileBuffers(part_handle);
-    CloseHandle(part_handle);
+    if (part_handle == INVALID_HANDLE_VALUE) return true;
+    bool ok = true;
+    if (flush && !FlushFileBuffers(part_handle)) ok = false;
+    if (!CloseHandle(part_handle)) ok = false;
     part_handle = INVALID_HANDLE_VALUE;
+    return ok;
     #else
-    if (part_fd < 0) return;
-    if (flush) durableSync(part_fd);
-    close(part_fd);
+    if (part_fd < 0) return true;
+    bool ok = true;
+    if (flush && durableSync(part_fd) != 0) ok = false;
+    if (close(part_fd) != 0) ok = false;
     part_fd = -1;
+    return ok;
     #endif
 }
 
@@ -216,8 +223,10 @@ bool writePartAt(size_t offset, const char* data, size_t len) {
     #endif
 }
 
+// Hash the received .part file back to compare against the announced digest. The
+// caller must have already flushed and closed it (verifyAndWrite does): a fresh
+// read handle is served from the page cache, so a failed sync can't be seen here.
 bool hashPartFile(uint8_t out[32]) {
-    closePartFile(true);
     std::ifstream in(part_path, std::ifstream::binary);
     if (!in.is_open()) return false;
     return Sha256::hashStream(in, file_length, out);
@@ -367,10 +376,9 @@ Finalize finalizeNoClobber(const std::string& tmp, const std::string& target) {
     #endif
 }
 
-// Move the verified on-disk .part file into place. On failure the .part file is
-// kept so the user does not lose a completed transfer.
+// Move the verified on-disk .part file into place; the caller already flushed and
+// closed it. On failure the .part file is kept so the user does not lose it.
 int finalizeVerifiedPart(const std::string& target) {
-    closePartFile(true);
     if (overwrite) {
         if (finalizeReplace(part_path, target)) {
             storage_ready = false;
@@ -468,7 +476,9 @@ constexpr size_t SNAPSHOT_HEADER = 51;
 // (nor pays the synchronous whole-buffer write) when interrupted.
 bool saveSnapshot() {
     if (!resume || !storage_ready || !have_session) return false;
-    closePartFile(true);
+    // A failed flush leaves the .part unreliable, so don't advertise a snapshot a
+    // later --resume would trust with parts that never durably landed.
+    if (!closePartFile(true)) return false;
     size_t total = totalParts();
     size_t bmSize = (total + 7) / 8;
     std::vector<char> idx(SNAPSHOT_HEADER + bmSize, 0);
@@ -565,6 +575,16 @@ int onRecoveryTimeout(size_t missing) {
 // Returns a process exit code.
 int verifyAndWrite() {
     reporter.finish();
+
+    // Flush to stable storage before trusting the bytes: the checksum below is
+    // served from the page cache, so a failed durable sync would otherwise pass
+    // as "sha256 verified" on data that never reached the disk.
+    if (!closePartFile(true)) {
+        std::cerr << "Error: Failed to flush received data to disk" << std::endl;
+        if (resume) discardSnapshot();
+        else removePartFiles();
+        return 2;
+    }
 
     uint8_t got[32];
     if (!hashPartFile(got)) {

--- a/tests/e2e_syncfail.sh
+++ b/tests/e2e_syncfail.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Durable-sync-failure end-to-end test: run a normal loopback transfer where
+# every part is delivered and written, but preload a shim (tests/failsync) into
+# the RECEIVER so its durable sync (fsync) fails with EIO. This pins the fix that
+# stops verifyAndWrite from announcing "sha256 verified" for data that never
+# reached the disk: the checksum re-read is served from the page cache and would
+# pass, so the failed sync must be caught at close time. The receiver must
+#
+#   * exit 2 and report "Failed to flush received data to disk",
+#   * NOT print "sha256 verified",
+#   * NOT produce the output file, and
+#   * leave no .part / .part.idx behind in EITHER mode (the flush failure cleans
+#     up exactly like a checksum mismatch: removePartFiles / discardSnapshot).
+#
+# Linux only: durableSync() uses fsync() here, which the shim shadows cleanly.
+# macOS flushes with fcntl(F_FULLFSYNC) instead, and interposing fcntl process-
+# wide is too fragile to fault-inject reliably, so the test self-skips there (the
+# receiver-side code being pinned is platform-independent).
+#
+# Run via:
+#   ctest --test-dir build --output-on-failure
+#
+# Or directly:
+#   BINARY=build/filecast FAILLIB=build/libfailsync.so bash tests/e2e_syncfail.sh
+#
+set -euo pipefail
+
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "SKIP: durable-sync fault injection is Linux-only (see script header)."
+    exit 0
+fi
+
+BINARY="${BINARY:-./filecast}"
+FAILLIB="${FAILLIB:-}"
+
+if [ ! -x "$BINARY" ]; then
+    echo "Error: $BINARY not found or not executable. Build first." >&2
+    exit 1
+fi
+if [ -z "$FAILLIB" ] || [ ! -f "$FAILLIB" ]; then
+    echo "Error: FAILLIB ($FAILLIB) not found; build the failsync shim first." >&2
+    exit 1
+fi
+
+PRELOAD_VAR="LD_PRELOAD"
+
+# An ASan build aborts when an interceptor shim is preloaded ahead of the ASan
+# runtime ("runtime does not come first"); waive just that check, keeping every
+# other ASan check active. Appended to any ASAN_OPTIONS the job already set.
+RECV_ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
+
+WORKDIR="$(mktemp -d -t fb-e2e-syncfail.XXXXXX)"
+RECV_PID=""
+SEND_PID=""
+
+cleanup() {
+    if [ -n "$RECV_PID" ]; then kill "$RECV_PID" 2>/dev/null || true; fi
+    if [ -n "$SEND_PID" ]; then kill "$SEND_PID" 2>/dev/null || true; fi
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# Direct loopback — the fault is injected locally, so no proxy is involved.
+RECV_BIND=33801
+SEND_BIND=33802
+
+# Args: label, extra receiver flag (e.g. "--resume" or "")
+run_syncfail_test() {
+    local label="$1"
+    local extra_flag="$2"
+    # Optional receiver flag as an array so an empty value expands to no argument.
+    # The +-guard keeps the expansion safe under `set -u` on bash 3.2 (macOS).
+    local -a extra=()
+    [ -n "$extra_flag" ] && extra=("$extra_flag")
+
+    local dir="$WORKDIR/$label"
+    mkdir -p "$dir"
+    local src="$dir/src.bin"
+    local recv_log="$dir/recv.log"
+    local send_log="$dir/send.log"
+
+    echo "==> [$label] generating 20 KiB file (all parts land, the sync will fail)"
+    dd if=/dev/urandom of="$src" bs=1024 count=20 status=none
+
+    echo "==> [$label] starting receiver (${extra_flag:-plain}) with sync->EIO shim"
+    env "$PRELOAD_VAR=$FAILLIB" ASAN_OPTIONS="$RECV_ASAN_OPTIONS" \
+        "$BINARY" receive "$dir/out.bin" --to 127.0.0.1 \
+                  --bind-port "$RECV_BIND" --port "$SEND_BIND" \
+                  --ttl 10 --delay-ms 0 ${extra[@]+"${extra[@]}"} > "$recv_log" 2>&1 &
+    RECV_PID=$!
+    sleep 1
+
+    echo "==> [$label] starting sender"
+    "$BINARY" send "$src" --to 127.0.0.1 \
+              --bind-port "$SEND_BIND" --port "$RECV_BIND" \
+              --ttl 5 --delay-ms 0 > "$send_log" 2>&1 &
+    SEND_PID=$!
+
+    # The receiver reassembles every part, fails the durable sync, and exits 2.
+    # Capture that code rather than letting `wait` abort the script under `set -e`.
+    local rc=0
+    wait "$RECV_PID" || rc=$?
+    RECV_PID=""
+
+    kill "$SEND_PID" 2>/dev/null || true; wait "$SEND_PID" 2>/dev/null || true; SEND_PID=""
+
+    if [ "$rc" -ne 2 ]; then
+        echo "FAIL: [$label] expected receiver exit 2, got $rc"
+        echo "--- receiver log (tail):"; tail -20 "$recv_log"
+        return 1
+    fi
+    if ! grep -q "Failed to flush received data to disk" "$recv_log"; then
+        echo "FAIL: [$label] receiver did not report a flush failure"
+        echo "--- receiver log (tail):"; tail -20 "$recv_log"
+        return 1
+    fi
+    # The core regression: a failed sync must never be announced as verified.
+    if grep -q "sha256 verified" "$recv_log"; then
+        echo "FAIL: [$label] receiver reported 'sha256 verified' despite the failed sync"
+        echo "--- receiver log (tail):"; tail -20 "$recv_log"
+        return 1
+    fi
+    if [ -f "$dir/out.bin" ]; then
+        echo "FAIL: [$label] output file was written despite the flush failure"
+        return 1
+    fi
+    # A flush failure cleans up like a checksum mismatch: neither mode keeps a
+    # .part or a .part.idx, since the bytes were never durably persisted.
+    if [ -f "$dir/out.bin.part" ] || [ -f "$dir/out.bin.part.idx" ]; then
+        echo "FAIL: [$label] left a .part/.part.idx behind:"
+        ls "$dir"
+        return 1
+    fi
+
+    echo "PASS: [$label] flush failure rejected (exit 2, not verified, no output)"
+}
+
+# Plain receive: flush failure -> removePartFiles() wipes the .part storage.
+run_syncfail_test "syncfail-plain"  ""
+# Resumable receive: flush failure -> discardSnapshot() drops the unreliable
+# .part/.part.idx rather than advertising un-synced parts to a later --resume.
+run_syncfail_test "syncfail-resume" "--resume"
+
+echo
+echo "All durable-sync-failure E2E tests passed."

--- a/tests/failsync.c
+++ b/tests/failsync.c
@@ -1,0 +1,36 @@
+/*
+ * Fault-injection shim that forces fsync(2) to fail with EIO, so a test can prove
+ * verifyAndWrite() no longer reports "sha256 verified" for data that never
+ * reached the disk. durableSync() in src/Receiver.cpp flushes with fsync() on
+ * Linux (F_FULLFSYNC on macOS — see e2e_syncfail.sh, which runs on Linux only),
+ * so failing fsync() drives closePartFile(true) to return false while the .part
+ * payload still sits in the page cache and the checksum re-read passes anyway —
+ * exactly the case the fix must catch.
+ *
+ * Loaded around the receiver under test only, via LD_PRELOAD. Written in C so the
+ * sanitizer CI job (which overrides CMAKE_CXX_FLAGS only) leaves it uninstrumented
+ * and it preloads cleanly ahead of the ASan runtime. injected_fsync() forwards
+ * nothing, so there is no dlsym reentrancy to worry about.
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <unistd.h>
+
+static int injected_fsync(int fd) {
+    (void)fd;
+    errno = EIO;
+    return -1;
+}
+
+#if defined(__APPLE__)
+/* Two-level namespaces ignore a plain override; __interpose remaps callers. */
+__attribute__((used, section("__DATA,__interpose")))
+static const void* interpose_fsync[2] = {
+    (const void*)&injected_fsync,
+    (const void*)&fsync,
+};
+#else
+int fsync(int fd) {
+    return injected_fsync(fd);
+}
+#endif


### PR DESCRIPTION
## Problem

`closePartFile()` was `void` and silently ignored both the durable sync
(`durableSync`/`FlushFileBuffers`) and the `close()`/`CloseHandle()` result.
This is a regression relative to the removed `writeTempFile()`, which used to
propagate both:

```cpp
if (ok && durableSync(fd) != 0) ok = false;  // flush data to disk before rename
if (close(fd) != 0) ok = false;
```

Why it's not a false positive: `verifyAndWrite()` re-reads the `.part` through a
**fresh** handle to checksum it, and that read is served from the **page cache**.
So a failed `fsync`/`F_FULLFSYNC` (full disk, I/O error, or a deferred write
error only surfaced at `close()` on NFS) still hashes correctly, and the
transfer is announced as `sha256 verified` on data that never durably reached
the disk.

### Reproduced (durableSync forced to fail, macOS)

| build | receiver exit | output |
|-------|---------------|--------|
| pre-fix  | `0`, prints `sha256 verified` ❌ | file written |
| this PR  | `2`, prints `Failed to flush received data to disk` ✅ | no file, cleaned up |

## Fix

`closePartFile()` now returns whether the requested flush **and** the close both
succeeded (the handle is always released either way), and the result is checked
on the durability-critical paths:

- **`verifyAndWrite()`** flushes + closes explicitly *before* hashing; a failure
  reports `Failed to flush received data to disk` and cleans up exactly like a
  checksum mismatch (exit 2, no output, no snapshot). `hashPartFile()` no longer
  closes — it just reads the already-closed file.
- **`finalizeVerifiedPart()`** drops its now-redundant close (the caller flushed).
- **`saveSnapshot()`** returns `false` on a failed flush, so a later `--resume`
  is never offered an `.idx` whose recorded parts never durably landed.

## Test

New `e2e_syncfail` test: a small C `LD_PRELOAD` shim (`tests/failsync.c`) forces
`fsync` to fail with `EIO` on an otherwise-complete loopback transfer, asserting
the receiver exits 2, reports the flush failure, and **never** prints
`sha256 verified` — in both plain and `--resume` modes. It fails against the
old code and passes with this fix.

Linux only: `durableSync()` uses `fsync()` there, which the shim shadows cleanly;
macOS flushes via `fcntl(F_FULLFSYNC)`, and interposing `fcntl` process-wide is
too fragile to fault-inject reliably, so the script self-skips there. The
receiver code being pinned is platform-independent.

Full suite (`unit`, `e2e`, `e2e_diskfull`, `e2e_syncfail`, `e2e_lossy`,
`e2e_corrupt`) passes locally.