### PR TITLE
[Security review][M1] Reject same-session ANNOUNCE that would reset or hijack a transfer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,19 @@ if(BUILD_TESTING)
                 ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE}"
                 TIMEOUT 120
             )
+
+            # Session-hijack variant: a Python UDP proxy injects one forged ANNOUNCE
+            # reusing the legitimate session id but claiming a different file, so a
+            # receiver that re-latched it would reset/hijack the transfer. Pins the
+            # same-session ANNOUNCE guard in handleAnnounce. Also needs Python 3.
+            add_test(
+                NAME e2e_hijack
+                COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/e2e_hijack.sh
+            )
+            set_tests_properties(e2e_hijack PROPERTIES
+                ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE}"
+                TIMEOUT 120
+            )
         else()
             message(STATUS "Python 3 not found — skipping e2e_lossy and e2e_corrupt tests")
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,27 +134,15 @@ if(BUILD_TESTING)
 
             # Session-hijack variant: a Python UDP proxy injects one forged ANNOUNCE
             # reusing the legitimate session id but claiming a different file, so a
-            # receiver that re-latched it would reset/hijack the transfer. Pins the
-            # same-session ANNOUNCE guard in handleAnnounce. Also needs Python 3.
+            # receiver that re-latched it would reset/hijack the transfer. The script
+            # runs both a valid-conflict and an invalid (out-of-range chunk) forgery
+            # to pin the same-session ANNOUNCE guard in handleAnnounce. Needs Python 3.
             add_test(
                 NAME e2e_hijack
                 COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/e2e_hijack.sh
             )
             set_tests_properties(e2e_hijack PROPERTIES
                 ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE}"
-                TIMEOUT 120
-            )
-
-            # Same proxy, but the forged ANNOUNCE claims an out-of-range chunk
-            # size. That packet would *fail* announceValid(); the guard must drop
-            # it first, so an invalid forgery cannot terminate the receiver (the
-            # one-packet DoS that survived when the guard ran after validation).
-            add_test(
-                NAME e2e_hijack_invalid
-                COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/e2e_hijack.sh
-            )
-            set_tests_properties(e2e_hijack_invalid PROPERTIES
-                ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE};FORGE_CHUNK=1"
                 TIMEOUT 120
             )
         else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,19 @@ if(BUILD_TESTING)
                 ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE}"
                 TIMEOUT 120
             )
+
+            # Same proxy, but the forged ANNOUNCE claims an out-of-range chunk
+            # size. That packet would *fail* announceValid(); the guard must drop
+            # it first, so an invalid forgery cannot terminate the receiver (the
+            # one-packet DoS that survived when the guard ran after validation).
+            add_test(
+                NAME e2e_hijack_invalid
+                COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/e2e_hijack.sh
+            )
+            set_tests_properties(e2e_hijack_invalid PROPERTIES
+                ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE};FORGE_CHUNK=1"
+                TIMEOUT 120
+            )
         else()
             message(STATUS "Python 3 not found — skipping e2e_lossy and e2e_corrupt tests")
         endif()

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -802,24 +802,11 @@ bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incomin
 
     if (!announceValid(announced, incoming_cs, exit_code)) return false;
 
-    // Once storage is open we are committed to this session's file. The gate
-    // above already dropped ANNOUNCEs from a different session, so anything that
-    // reaches here carries our session id — which travels in cleartext in every
-    // broadcast packet, so any host on the LAN can read it and replay it. A
-    // same-session ANNOUNCE is therefore one of two things:
-    //
-    //   * matching file_length/chunk_size/hash -> a duplicate retransmission;
-    //     keep the parts we have already accumulated and carry on.
-    //   * differing in any of them -> hostile or corrupt, and must be refused.
-    //     Re-latching would let prepareStorage ftruncate the .part and clear the
-    //     bitmap, so a single forged datagram could reset an almost-complete
-    //     transfer (a repeatable one-packet DoS) or — by also swapping in the
-    //     attacker's hash and name — make injected bytes verify as "sha256
-    //     verified" under a chosen name, defeating the whole integrity guarantee.
-    //
-    // Never reset an active transfer from the network. A sender that genuinely
-    // restarts with a new file draws a fresh session id and is handled by the
-    // different-session gate above.
+    // Never reset an active transfer from the network. The session id is public
+    // (cleartext in every broadcast), so a same-session ANNOUNCE that differs is
+    // hostile or corrupt: re-latching would ftruncate the .part and swap the hash,
+    // resetting or hijacking the transfer. Drop it; a matching one is a harmless
+    // retransmission. A genuine restart draws a fresh session id (handled above).
     if (storage_ready) {
         bool same = announced == file_length && incoming_cs == chunk_size &&
                     memcmp(expected_hash, buf + Protocol::HEADER_SIZE + 8, 32) == 0;

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -802,8 +802,33 @@ bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incomin
 
     if (!announceValid(announced, incoming_cs, exit_code)) return false;
 
-    // Duplicate retransmission of the same ANNOUNCE: keep accumulated parts.
-    if (storage_ready && announced == file_length && incoming_cs == chunk_size) return true;
+    // Once storage is open we are committed to this session's file. The gate
+    // above already dropped ANNOUNCEs from a different session, so anything that
+    // reaches here carries our session id — which travels in cleartext in every
+    // broadcast packet, so any host on the LAN can read it and replay it. A
+    // same-session ANNOUNCE is therefore one of two things:
+    //
+    //   * matching file_length/chunk_size/hash -> a duplicate retransmission;
+    //     keep the parts we have already accumulated and carry on.
+    //   * differing in any of them -> hostile or corrupt, and must be refused.
+    //     Re-latching would let prepareStorage ftruncate the .part and clear the
+    //     bitmap, so a single forged datagram could reset an almost-complete
+    //     transfer (a repeatable one-packet DoS) or — by also swapping in the
+    //     attacker's hash and name — make injected bytes verify as "sha256
+    //     verified" under a chosen name, defeating the whole integrity guarantee.
+    //
+    // Never reset an active transfer from the network. A sender that genuinely
+    // restarts with a new file draws a fresh session id and is handled by the
+    // different-session gate above.
+    if (storage_ready) {
+        bool same = announced == file_length && incoming_cs == chunk_size &&
+                    memcmp(expected_hash, buf + Protocol::HEADER_SIZE + 8, 32) == 0;
+        if (!same) {
+            std::cerr << "Warning: ignoring conflicting announcement for the active session"
+                      << std::endl;
+        }
+        return true;
+    }
 
     session_id   = incoming_sid;
     have_session = true;

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -794,28 +794,35 @@ bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incomin
     size_t name_len    = Protocol::getU16(buf + Protocol::HEADER_SIZE + 40);
     if (static_cast<size_t>(length) < Protocol::ANNOUNCE_FIXED + name_len) return true;  // truncated
 
-    // Only a recognised packet from our sender refreshes ttl. Unrecognised
-    // traffic (stray broadcasts, other receivers' RESENDs, garbage) deliberately
-    // does not, so the timeout stays reachable and a hostile or noisy host cannot
-    // keep the receiver alive forever.
-    ttl = ttl_max;
-
-    if (!announceValid(announced, incoming_cs, exit_code)) return false;
-
-    // Never reset an active transfer from the network. The session id is public
-    // (cleartext in every broadcast), so a same-session ANNOUNCE that differs is
-    // hostile or corrupt: re-latching would ftruncate the .part and swap the hash,
-    // resetting or hijacking the transfer. Drop it; a matching one is a harmless
-    // retransmission. A genuine restart draws a fresh session id (handled above).
+    // Once storage is open we are committed to this session's file. The session
+    // id is public (cleartext in every broadcast), so any same-session ANNOUNCE
+    // that differs is hostile or corrupt: re-latching would ftruncate the .part
+    // and swap the hash, resetting or hijacking the transfer. Drop it here,
+    // *before* announceValid() and *before* refreshing ttl -- a forged empty file
+    // or out-of-range chunk size would otherwise fail validation and terminate
+    // the receiver (a one-packet DoS), and letting forgeries refresh ttl would
+    // let a hostile host hold the receiver open indefinitely. A matching ANNOUNCE
+    // is a harmless retransmission from our sender and does refresh ttl; a genuine
+    // restart draws a fresh session id and is rejected by the gate above.
     if (storage_ready) {
         bool same = announced == file_length && incoming_cs == chunk_size &&
                     memcmp(expected_hash, buf + Protocol::HEADER_SIZE + 8, 32) == 0;
         if (!same) {
             std::cerr << "Warning: ignoring conflicting announcement for the active session"
                       << std::endl;
+            return true;
         }
+        ttl = ttl_max;
         return true;
     }
+
+    // First ANNOUNCE of the run. Only a recognised packet from our sender
+    // refreshes ttl; unrecognised traffic (stray broadcasts, other receivers'
+    // RESENDs, garbage) deliberately does not, so the timeout stays reachable and
+    // a hostile or noisy host cannot keep the receiver alive forever.
+    ttl = ttl_max;
+
+    if (!announceValid(announced, incoming_cs, exit_code)) return false;
 
     session_id   = incoming_sid;
     have_session = true;

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -794,16 +794,10 @@ bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incomin
     size_t name_len    = Protocol::getU16(buf + Protocol::HEADER_SIZE + 40);
     if (static_cast<size_t>(length) < Protocol::ANNOUNCE_FIXED + name_len) return true;  // truncated
 
-    // Once storage is open we are committed to this session's file. The session
-    // id is public (cleartext in every broadcast), so any same-session ANNOUNCE
-    // that differs is hostile or corrupt: re-latching would ftruncate the .part
-    // and swap the hash, resetting or hijacking the transfer. Drop it here,
-    // *before* announceValid() and *before* refreshing ttl -- a forged empty file
-    // or out-of-range chunk size would otherwise fail validation and terminate
-    // the receiver (a one-packet DoS), and letting forgeries refresh ttl would
-    // let a hostile host hold the receiver open indefinitely. A matching ANNOUNCE
-    // is a harmless retransmission from our sender and does refresh ttl; a genuine
-    // restart draws a fresh session id and is rejected by the gate above.
+    // Storage open means we are committed to this session's file. Drop a differing
+    // same-session ANNOUNCE before announceValid() and the ttl refresh, so a forged
+    // empty/oversized one can neither fail validation and kill the receiver nor
+    // hold it open. A matching one just refreshes ttl; a restart draws a new session.
     if (storage_ready) {
         bool same = announced == file_length && incoming_cs == chunk_size &&
                     memcmp(expected_hash, buf + Protocol::HEADER_SIZE + 8, 32) == 0;
@@ -816,10 +810,10 @@ bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incomin
         return true;
     }
 
-    // First ANNOUNCE of the run. Only a recognised packet from our sender
-    // refreshes ttl; unrecognised traffic (stray broadcasts, other receivers'
-    // RESENDs, garbage) deliberately does not, so the timeout stays reachable and
-    // a hostile or noisy host cannot keep the receiver alive forever.
+    // Only a recognised packet from our sender refreshes ttl. Unrecognised
+    // traffic (stray broadcasts, other receivers' RESENDs, garbage) deliberately
+    // does not, so the timeout stays reachable and a hostile or noisy host cannot
+    // keep the receiver alive forever.
     ttl = ttl_max;
 
     if (!announceValid(announced, incoming_cs, exit_code)) return false;

--- a/tests/e2e_hijack.sh
+++ b/tests/e2e_hijack.sh
@@ -7,17 +7,29 @@
 # to refuse the forgery, exit 0, report "sha256 verified", produce a byte-identical
 # output, write no "evil" file, and log that it ignored the conflicting ANNOUNCE.
 #
+# FORGE_LENGTH / FORGE_CHUNK select what the forgery claims. The default is a
+# well-formed conflicting file; setting FORGE_CHUNK to an out-of-range value (or
+# FORGE_LENGTH=0) forges an ANNOUNCE that would *fail* the receiver's range check.
+# That case matters because the guard has to drop it before announceValid() runs,
+# otherwise the forged packet terminates the receiver -- a one-packet DoS.
+#
 # Run via:
 #   ctest --test-dir build --output-on-failure
 #
 # Or directly:
 #   BINARY=build/filecast bash tests/e2e_hijack.sh
+#   BINARY=build/filecast FORGE_CHUNK=1 bash tests/e2e_hijack.sh   # invalid forgery
 #
 set -euo pipefail
 
 BINARY="${BINARY:-./filecast}"
 PYTHON="${PYTHON:-python3}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# What the injected forgery claims. Defaults describe a valid-but-conflicting
+# file; override to forge values the receiver's announceValid() would reject.
+FORGE_LENGTH="${FORGE_LENGTH:-4096}"
+FORGE_CHUNK="${FORGE_CHUNK:-1400}"
 
 if [ ! -x "$BINARY" ]; then
     echo "Error: $BINARY not found or not executable. Build first." >&2
@@ -64,10 +76,11 @@ proxy_log="$dir/proxy.log"
 echo "==> generating 500 KiB file (a forged same-session ANNOUNCE will be injected)"
 dd if=/dev/urandom of="$src" bs=1024 count=500 status=none
 
-echo "==> starting hijack proxy"
+echo "==> starting hijack proxy (forge length=$FORGE_LENGTH chunk=$FORGE_CHUNK)"
 "$PYTHON" "$SCRIPT_DIR/hijack_proxy.py" \
     --listen-fwd  "$PROXY_FWD_IN"  --target-fwd  "$RECV_BIND" \
     --listen-back "$PROXY_BACK_IN" --target-back "$SEND_BIND" \
+    --forge-length "$FORGE_LENGTH" --forge-chunk "$FORGE_CHUNK" \
     > "$proxy_log" 2>&1 &
 PROXY_PID=$!
 sleep 0.5  # let the proxy bind both sockets

--- a/tests/e2e_hijack.sh
+++ b/tests/e2e_hijack.sh
@@ -7,29 +7,23 @@
 # to refuse the forgery, exit 0, report "sha256 verified", produce a byte-identical
 # output, write no "evil" file, and log that it ignored the conflicting ANNOUNCE.
 #
-# FORGE_LENGTH / FORGE_CHUNK select what the forgery claims. The default is a
-# well-formed conflicting file; setting FORGE_CHUNK to an out-of-range value (or
-# FORGE_LENGTH=0) forges an ANNOUNCE that would *fail* the receiver's range check.
-# That case matters because the guard has to drop it before announceValid() runs,
-# otherwise the forged packet terminates the receiver -- a one-packet DoS.
+# Two scenarios run in sequence:
+#   valid   -- the forgery claims a well-formed but conflicting file.
+#   invalid -- the forgery claims an out-of-range chunk size, which would *fail*
+#              announceValid(); the guard must drop it before that check runs, or
+#              the forged packet terminates the receiver -- a one-packet DoS.
 #
 # Run via:
 #   ctest --test-dir build --output-on-failure
 #
 # Or directly:
 #   BINARY=build/filecast bash tests/e2e_hijack.sh
-#   BINARY=build/filecast FORGE_CHUNK=1 bash tests/e2e_hijack.sh   # invalid forgery
 #
 set -euo pipefail
 
 BINARY="${BINARY:-./filecast}"
 PYTHON="${PYTHON:-python3}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-
-# What the injected forgery claims. Defaults describe a valid-but-conflicting
-# file; override to forge values the receiver's announceValid() would reject.
-FORGE_LENGTH="${FORGE_LENGTH:-4096}"
-FORGE_CHUNK="${FORGE_CHUNK:-1400}"
 
 if [ ! -x "$BINARY" ]; then
     echo "Error: $BINARY not found or not executable. Build first." >&2
@@ -47,99 +41,116 @@ RECV_PID=""
 SEND_PID=""
 
 cleanup() {
-    if [ -n "$RECV_PID"  ]; then kill "$RECV_PID"  2>/dev/null || true; fi
-    if [ -n "$SEND_PID"  ]; then kill "$SEND_PID"  2>/dev/null || true; fi
-    if [ -n "$PROXY_PID" ]; then kill "$PROXY_PID" 2>/dev/null || true; fi
+    [ -n "$RECV_PID"  ] && kill "$RECV_PID"  2>/dev/null || true
+    [ -n "$SEND_PID"  ] && kill "$SEND_PID"  2>/dev/null || true
+    [ -n "$PROXY_PID" ] && kill "$PROXY_PID" 2>/dev/null || true
     rm -rf "$WORKDIR"
 }
 trap cleanup EXIT
 
-# Topology (all on 127.0.0.1):
-#   sender bind   = 33702, sender   target -> 33703 (proxy fwd in, injects forgery)
-#   receiver bind = 33701, receiver target -> 33704 (proxy back in, clean)
-#   proxy fwd:  33703 -> 33701  (sender->receiver, one forged ANNOUNCE injected)
-#   proxy back: 33704 -> 33702  (receiver->sender, untouched)
-RECV_BIND=33701
-SEND_BIND=33702
-PROXY_FWD_IN=33703
-PROXY_BACK_IN=33704
-
-dir="$WORKDIR/hijack"
-mkdir -p "$dir"
-src="$dir/src.bin"
-recv_log="$dir/recv.log"
-send_log="$dir/send.log"
-proxy_log="$dir/proxy.log"
-
-# A few hundred KiB so the transfer spans many parts and is still in progress
-# when the forged ANNOUNCE lands (the proxy fires it after the first TRANSFER).
-echo "==> generating 500 KiB file (a forged same-session ANNOUNCE will be injected)"
-dd if=/dev/urandom of="$src" bs=1024 count=500 status=none
-
-echo "==> starting hijack proxy (forge length=$FORGE_LENGTH chunk=$FORGE_CHUNK)"
-"$PYTHON" "$SCRIPT_DIR/hijack_proxy.py" \
-    --listen-fwd  "$PROXY_FWD_IN"  --target-fwd  "$RECV_BIND" \
-    --listen-back "$PROXY_BACK_IN" --target-back "$SEND_BIND" \
-    --forge-length "$FORGE_LENGTH" --forge-chunk "$FORGE_CHUNK" \
-    > "$proxy_log" 2>&1 &
-PROXY_PID=$!
-sleep 0.5  # let the proxy bind both sockets
-
-echo "==> starting receiver"
-# An explicit output path keeps every artifact inside $dir and pins the output
-# name from the CLI, so the forged ANNOUNCE cannot even influence the file name.
-"$BINARY" receive "$dir/out.bin" --to 127.0.0.1 \
-          --bind-port "$RECV_BIND" --port "$PROXY_BACK_IN" \
-          --ttl 15 --delay-ms 0 > "$recv_log" 2>&1 &
-RECV_PID=$!
-sleep 1
-
-echo "==> starting sender"
-"$BINARY" send "$src" --to 127.0.0.1 \
-          --bind-port "$SEND_BIND" --port "$PROXY_FWD_IN" \
-          --ttl 10 --delay-ms 0 > "$send_log" 2>&1 &
-SEND_PID=$!
-
-# The receiver should ignore the forgery, finish the real transfer and exit 0.
-rc=0
-wait "$RECV_PID" || rc=$?
-RECV_PID=""
-
-kill "$SEND_PID"  2>/dev/null || true; wait "$SEND_PID"  2>/dev/null || true; SEND_PID=""
-kill "$PROXY_PID" 2>/dev/null || true; wait "$PROXY_PID" 2>/dev/null || true; PROXY_PID=""
+# Topology (all on 127.0.0.1). Its own 339xx port block keeps ctest -j from
+# colliding with the other e2e tests:
+#   sender bind   = 33902, sender   target -> 33903 (proxy fwd in, injects forgery)
+#   receiver bind = 33901, receiver target -> 33904 (proxy back in, clean)
+#   proxy fwd:  33903 -> 33901  (sender->receiver, one forged ANNOUNCE injected)
+#   proxy back: 33904 -> 33902  (receiver->sender, untouched)
+RECV_BIND=33901
+SEND_BIND=33902
+PROXY_FWD_IN=33903
+PROXY_BACK_IN=33904
 
 fail() {
-    echo "FAIL: $1"
+    echo "FAIL: [$label] $1"
     echo "--- receiver log (tail):"; tail -20 "$recv_log"
     echo "--- proxy log (tail):";    tail -20 "$proxy_log"
     exit 1
 }
 
-# Sanity: if the proxy never injected, the test would pass for the wrong reason.
-if ! grep -q "injected forged same-session ANNOUNCE" "$proxy_log"; then
-    fail "proxy never injected a forged ANNOUNCE"
-fi
-if [ "$rc" -ne 0 ]; then
-    fail "expected receiver exit 0, got $rc (forged ANNOUNCE was honoured?)"
-fi
-if [ ! -f "$dir/out.bin" ]; then
-    fail "receiver did not produce the output file"
-fi
-if ! cmp -s "$src" "$dir/out.bin"; then
-    fail "received file does not match source (transfer was corrupted/reset)"
-fi
-if ! grep -q "sha256 verified" "$recv_log"; then
-    fail "receiver did not report a verified transfer"
-fi
-# The forged name must never touch the disk.
-if [ -f "$dir/evil" ] || [ -f "$dir/evil.part" ]; then
-    fail "forged file name was written to disk"
-fi
-# Proof the guard actually fired rather than the forgery racing past the finish.
-if ! grep -q "ignoring conflicting announcement" "$recv_log"; then
-    fail "receiver never logged that it refused the conflicting announcement"
-fi
+# Args: label, forge_length, forge_chunk. The forgery reuses the sniffed session
+# id but claims (forge_length, forge_chunk); the receiver must refuse it and still
+# finish the real transfer.
+run_test() {
+    local label="$1"
+    local forge_length="$2"
+    local forge_chunk="$3"
 
-echo "PASS: forged same-session ANNOUNCE refused; real transfer verified (exit 0)"
+    local dir="$WORKDIR/$label"
+    mkdir -p "$dir"
+    local src="$dir/src.bin"
+    local recv_log="$dir/recv.log"
+    local send_log="$dir/send.log"
+    local proxy_log="$dir/proxy.log"
+
+    # A few hundred KiB so the transfer spans many parts and is still in progress
+    # when the forged ANNOUNCE lands (the proxy fires it after the first TRANSFER).
+    echo "==> [$label] generating 500 KiB file (forge length=$forge_length chunk=$forge_chunk)"
+    dd if=/dev/urandom of="$src" bs=1024 count=500 status=none
+
+    echo "==> [$label] starting hijack proxy"
+    "$PYTHON" "$SCRIPT_DIR/hijack_proxy.py" \
+        --listen-fwd  "$PROXY_FWD_IN"  --target-fwd  "$RECV_BIND" \
+        --listen-back "$PROXY_BACK_IN" --target-back "$SEND_BIND" \
+        --forge-length "$forge_length" --forge-chunk "$forge_chunk" \
+        > "$proxy_log" 2>&1 &
+    PROXY_PID=$!
+    sleep 0.5  # let the proxy bind both sockets
+
+    echo "==> [$label] starting receiver"
+    # An explicit output path keeps every artifact inside $dir and pins the output
+    # name from the CLI, so the forged ANNOUNCE cannot even influence the file name.
+    "$BINARY" receive "$dir/out.bin" --to 127.0.0.1 \
+              --bind-port "$RECV_BIND" --port "$PROXY_BACK_IN" \
+              --ttl 15 --delay-ms 0 > "$recv_log" 2>&1 &
+    RECV_PID=$!
+    sleep 1
+
+    echo "==> [$label] starting sender"
+    "$BINARY" send "$src" --to 127.0.0.1 \
+              --bind-port "$SEND_BIND" --port "$PROXY_FWD_IN" \
+              --ttl 10 --delay-ms 0 > "$send_log" 2>&1 &
+    SEND_PID=$!
+
+    # The receiver should ignore the forgery, finish the real transfer and exit 0.
+    local rc=0
+    wait "$RECV_PID" || rc=$?
+    RECV_PID=""
+
+    kill "$SEND_PID"  2>/dev/null || true; wait "$SEND_PID"  2>/dev/null || true; SEND_PID=""
+    kill "$PROXY_PID" 2>/dev/null || true; wait "$PROXY_PID" 2>/dev/null || true; PROXY_PID=""
+
+    # Sanity: if the proxy never injected, the test would pass for the wrong reason.
+    if ! grep -q "injected forged same-session ANNOUNCE" "$proxy_log"; then
+        fail "proxy never injected a forged ANNOUNCE"
+    fi
+    if [ "$rc" -ne 0 ]; then
+        fail "expected receiver exit 0, got $rc (forged ANNOUNCE was honoured?)"
+    fi
+    if [ ! -f "$dir/out.bin" ]; then
+        fail "receiver did not produce the output file"
+    fi
+    if ! cmp -s "$src" "$dir/out.bin"; then
+        fail "received file does not match source (transfer was corrupted/reset)"
+    fi
+    if ! grep -q "sha256 verified" "$recv_log"; then
+        fail "receiver did not report a verified transfer"
+    fi
+    # The forged name must never touch the disk.
+    if [ -f "$dir/evil" ] || [ -f "$dir/evil.part" ]; then
+        fail "forged file name was written to disk"
+    fi
+    # Proof the guard actually fired rather than the forgery racing past the finish.
+    if ! grep -q "ignoring conflicting announcement" "$recv_log"; then
+        fail "receiver never logged that it refused the conflicting announcement"
+    fi
+
+    echo "PASS: [$label] forged same-session ANNOUNCE refused; real transfer verified (exit 0)"
+}
+
+# A valid-but-conflicting forgery, then one whose out-of-range chunk size would
+# fail announceValid() -- the guard has to drop it before that check to avoid the
+# one-packet DoS.
+run_test "valid"   4096 1400
+run_test "invalid" 4096 1
+
 echo
 echo "Hijack E2E test passed."

--- a/tests/e2e_hijack.sh
+++ b/tests/e2e_hijack.sh
@@ -1,20 +1,11 @@
 #!/usr/bin/env bash
 #
-# Session-hijack end-to-end test: run a real transfer through a proxy that, once
-# the transfer is under way, injects ONE forged ANNOUNCE reusing the legitimate
-# (cleartext) session id but claiming a different file_length, sha256 and name.
-#
-# This pins the same-session ANNOUNCE guard in handleAnnounce. On a receiver that
-# re-latches such a packet, the forgery truncates the .part, wipes the parts
-# bitmap and swaps in the attacker's hash — so an almost-complete transfer either
-# never finishes or fails its checksum (a one-packet, repeatable reset, and a way
-# to make injected bytes verify under a chosen name). A receiver that honours the
-# guard refuses the forgery and the real transfer completes and verifies:
-#
-#   * the receiver must exit 0 and report "sha256 verified",
-#   * the output file must match the source byte-for-byte,
-#   * no "evil" file (the forged name) may appear, and
-#   * the receiver must have logged that it ignored the conflicting announcement.
+# Session-hijack end-to-end test: a proxy injects one forged ANNOUNCE mid-transfer
+# reusing the legitimate session id but claiming a different file_length/sha256/
+# name. This pins the same-session ANNOUNCE guard in handleAnnounce: a receiver
+# that re-latched it would reset/hijack the transfer, so we require the receiver
+# to refuse the forgery, exit 0, report "sha256 verified", produce a byte-identical
+# output, write no "evil" file, and log that it ignored the conflicting ANNOUNCE.
 #
 # Run via:
 #   ctest --test-dir build --output-on-failure

--- a/tests/e2e_hijack.sh
+++ b/tests/e2e_hijack.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Session-hijack end-to-end test: run a real transfer through a proxy that, once
+# the transfer is under way, injects ONE forged ANNOUNCE reusing the legitimate
+# (cleartext) session id but claiming a different file_length, sha256 and name.
+#
+# This pins the same-session ANNOUNCE guard in handleAnnounce. On a receiver that
+# re-latches such a packet, the forgery truncates the .part, wipes the parts
+# bitmap and swaps in the attacker's hash — so an almost-complete transfer either
+# never finishes or fails its checksum (a one-packet, repeatable reset, and a way
+# to make injected bytes verify under a chosen name). A receiver that honours the
+# guard refuses the forgery and the real transfer completes and verifies:
+#
+#   * the receiver must exit 0 and report "sha256 verified",
+#   * the output file must match the source byte-for-byte,
+#   * no "evil" file (the forged name) may appear, and
+#   * the receiver must have logged that it ignored the conflicting announcement.
+#
+# Run via:
+#   ctest --test-dir build --output-on-failure
+#
+# Or directly:
+#   BINARY=build/filecast bash tests/e2e_hijack.sh
+#
+set -euo pipefail
+
+BINARY="${BINARY:-./filecast}"
+PYTHON="${PYTHON:-python3}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ ! -x "$BINARY" ]; then
+    echo "Error: $BINARY not found or not executable. Build first." >&2
+    exit 1
+fi
+
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    echo "Error: $PYTHON not found in PATH; hijack proxy needs Python 3." >&2
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d -t fb-e2e-hijack.XXXXXX)"
+PROXY_PID=""
+RECV_PID=""
+SEND_PID=""
+
+cleanup() {
+    if [ -n "$RECV_PID"  ]; then kill "$RECV_PID"  2>/dev/null || true; fi
+    if [ -n "$SEND_PID"  ]; then kill "$SEND_PID"  2>/dev/null || true; fi
+    if [ -n "$PROXY_PID" ]; then kill "$PROXY_PID" 2>/dev/null || true; fi
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# Topology (all on 127.0.0.1):
+#   sender bind   = 33702, sender   target -> 33703 (proxy fwd in, injects forgery)
+#   receiver bind = 33701, receiver target -> 33704 (proxy back in, clean)
+#   proxy fwd:  33703 -> 33701  (sender->receiver, one forged ANNOUNCE injected)
+#   proxy back: 33704 -> 33702  (receiver->sender, untouched)
+RECV_BIND=33701
+SEND_BIND=33702
+PROXY_FWD_IN=33703
+PROXY_BACK_IN=33704
+
+dir="$WORKDIR/hijack"
+mkdir -p "$dir"
+src="$dir/src.bin"
+recv_log="$dir/recv.log"
+send_log="$dir/send.log"
+proxy_log="$dir/proxy.log"
+
+# A few hundred KiB so the transfer spans many parts and is still in progress
+# when the forged ANNOUNCE lands (the proxy fires it after the first TRANSFER).
+echo "==> generating 500 KiB file (a forged same-session ANNOUNCE will be injected)"
+dd if=/dev/urandom of="$src" bs=1024 count=500 status=none
+
+echo "==> starting hijack proxy"
+"$PYTHON" "$SCRIPT_DIR/hijack_proxy.py" \
+    --listen-fwd  "$PROXY_FWD_IN"  --target-fwd  "$RECV_BIND" \
+    --listen-back "$PROXY_BACK_IN" --target-back "$SEND_BIND" \
+    > "$proxy_log" 2>&1 &
+PROXY_PID=$!
+sleep 0.5  # let the proxy bind both sockets
+
+echo "==> starting receiver"
+# An explicit output path keeps every artifact inside $dir and pins the output
+# name from the CLI, so the forged ANNOUNCE cannot even influence the file name.
+"$BINARY" receive "$dir/out.bin" --to 127.0.0.1 \
+          --bind-port "$RECV_BIND" --port "$PROXY_BACK_IN" \
+          --ttl 15 --delay-ms 0 > "$recv_log" 2>&1 &
+RECV_PID=$!
+sleep 1
+
+echo "==> starting sender"
+"$BINARY" send "$src" --to 127.0.0.1 \
+          --bind-port "$SEND_BIND" --port "$PROXY_FWD_IN" \
+          --ttl 10 --delay-ms 0 > "$send_log" 2>&1 &
+SEND_PID=$!
+
+# The receiver should ignore the forgery, finish the real transfer and exit 0.
+rc=0
+wait "$RECV_PID" || rc=$?
+RECV_PID=""
+
+kill "$SEND_PID"  2>/dev/null || true; wait "$SEND_PID"  2>/dev/null || true; SEND_PID=""
+kill "$PROXY_PID" 2>/dev/null || true; wait "$PROXY_PID" 2>/dev/null || true; PROXY_PID=""
+
+fail() {
+    echo "FAIL: $1"
+    echo "--- receiver log (tail):"; tail -20 "$recv_log"
+    echo "--- proxy log (tail):";    tail -20 "$proxy_log"
+    exit 1
+}
+
+# Sanity: if the proxy never injected, the test would pass for the wrong reason.
+if ! grep -q "injected forged same-session ANNOUNCE" "$proxy_log"; then
+    fail "proxy never injected a forged ANNOUNCE"
+fi
+if [ "$rc" -ne 0 ]; then
+    fail "expected receiver exit 0, got $rc (forged ANNOUNCE was honoured?)"
+fi
+if [ ! -f "$dir/out.bin" ]; then
+    fail "receiver did not produce the output file"
+fi
+if ! cmp -s "$src" "$dir/out.bin"; then
+    fail "received file does not match source (transfer was corrupted/reset)"
+fi
+if ! grep -q "sha256 verified" "$recv_log"; then
+    fail "receiver did not report a verified transfer"
+fi
+# The forged name must never touch the disk.
+if [ -f "$dir/evil" ] || [ -f "$dir/evil.part" ]; then
+    fail "forged file name was written to disk"
+fi
+# Proof the guard actually fired rather than the forgery racing past the finish.
+if ! grep -q "ignoring conflicting announcement" "$recv_log"; then
+    fail "receiver never logged that it refused the conflicting announcement"
+fi
+
+echo "PASS: forged same-session ANNOUNCE refused; real transfer verified (exit 0)"
+echo
+echo "Hijack E2E test passed."

--- a/tests/e2e_hijack.sh
+++ b/tests/e2e_hijack.sh
@@ -41,9 +41,9 @@ RECV_PID=""
 SEND_PID=""
 
 cleanup() {
-    [ -n "$RECV_PID"  ] && kill "$RECV_PID"  2>/dev/null || true
-    [ -n "$SEND_PID"  ] && kill "$SEND_PID"  2>/dev/null || true
-    [ -n "$PROXY_PID" ] && kill "$PROXY_PID" 2>/dev/null || true
+    if [ -n "$RECV_PID"  ]; then kill "$RECV_PID"  2>/dev/null || true; fi
+    if [ -n "$SEND_PID"  ]; then kill "$SEND_PID"  2>/dev/null || true; fi
+    if [ -n "$PROXY_PID" ]; then kill "$PROXY_PID" 2>/dev/null || true; fi
     rm -rf "$WORKDIR"
 }
 trap cleanup EXIT

--- a/tests/hijack_proxy.py
+++ b/tests/hijack_proxy.py
@@ -1,24 +1,11 @@
 #!/usr/bin/env python3
 """Session-hijack UDP proxy for exercising the same-session ANNOUNCE guard."""
 #
-# Like corrupt_proxy.py this runs two unidirectional proxies in one process:
-#
-#   * Forward direction:  listen-fwd  -> target-fwd  (sender -> receiver path)
-#   * Backward direction: listen-back -> target-back (receiver -> sender path)
-#
-# It forwards every real packet byte-for-byte, but models a LAN attacker who has
-# sniffed the cleartext session id out of a broadcast: once the legitimate
-# ANNOUNCE has passed and the transfer is under way (after the first TRANSFER),
-# it injects ONE forged ANNOUNCE straight at the receiver. The forgery reuses the
-# real session id — so it slips past the receiver's different-session gate — but
-# carries a different file_length, sha256 and name.
-#
-# Against an unfixed receiver this re-latches the session: the .part is truncated,
-# the parts bitmap is wiped and the expected hash is swapped for the attacker's,
-# so the transfer can never complete/verify (the receiver times out or reports a
-# checksum mismatch). Against the fixed receiver the forged ANNOUNCE is refused,
-# the real transfer finishes and the file verifies. The injection is fired exactly
-# once, after the first data-bearing TRANSFER, so the outcome is deterministic.
+# Like corrupt_proxy.py, forwards every real packet byte-for-byte but models a LAN
+# attacker who sniffed the cleartext session id: after the first TRANSFER it
+# injects ONE forged ANNOUNCE that reuses the session id (so it passes the
+# different-session gate) yet claims a different file_length/sha256/name. Fired
+# exactly once, so the outcome is deterministic.
 
 import argparse
 import socket

--- a/tests/hijack_proxy.py
+++ b/tests/hijack_proxy.py
@@ -22,12 +22,9 @@ TYPE_TRANSFER = 2
 HEADER_SIZE = 10
 ANNOUNCE_FIXED = HEADER_SIZE + 42  # header + size(4) + chunk(4) + hash(32) + name_len(2)
 
-# The forged file the attacker claims. A different length is enough to miss the
-# receiver's duplicate-ANNOUNCE check and drive the (buggy) re-latch path. The
-# length and chunk size are overridable so the test can also forge values that
-# would *fail* the receiver's range check (empty file, out-of-range chunk): those
-# must be dropped by the same-session guard before announceValid() turns them into
-# a fatal error -- the one-packet DoS the guard has to close.
+# The forged file the attacker claims. Length/chunk are overridable so the test
+# can also forge values announceValid() rejects (empty file, out-of-range chunk),
+# which the guard must drop before they become a fatal error.
 FORGED_NAME = b"evil"
 FORGED_HASH = bytes([0xAB]) * 32
 

--- a/tests/hijack_proxy.py
+++ b/tests/hijack_proxy.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Session-hijack UDP proxy for exercising the same-session ANNOUNCE guard."""
+#
+# Like corrupt_proxy.py this runs two unidirectional proxies in one process:
+#
+#   * Forward direction:  listen-fwd  -> target-fwd  (sender -> receiver path)
+#   * Backward direction: listen-back -> target-back (receiver -> sender path)
+#
+# It forwards every real packet byte-for-byte, but models a LAN attacker who has
+# sniffed the cleartext session id out of a broadcast: once the legitimate
+# ANNOUNCE has passed and the transfer is under way (after the first TRANSFER),
+# it injects ONE forged ANNOUNCE straight at the receiver. The forgery reuses the
+# real session id — so it slips past the receiver's different-session gate — but
+# carries a different file_length, sha256 and name.
+#
+# Against an unfixed receiver this re-latches the session: the .part is truncated,
+# the parts bitmap is wiped and the expected hash is swapped for the attacker's,
+# so the transfer can never complete/verify (the receiver times out or reports a
+# checksum mismatch). Against the fixed receiver the forged ANNOUNCE is refused,
+# the real transfer finishes and the file verifies. The injection is fired exactly
+# once, after the first data-bearing TRANSFER, so the outcome is deterministic.
+
+import argparse
+import socket
+import sys
+import threading
+
+# Wire layout mirrored from src/Protocol.hpp (protocol v3):
+#   magic "FCST"(4) + version(1) + type(1) + session(4) = 10-byte header.
+# ANNOUNCE then adds file_size(4) + chunk_size(4) + sha256(32) + name_len(2),
+# and finally the variable-length name.
+MAGIC = b"FCST"
+TYPE_ANNOUNCE = 1
+TYPE_TRANSFER = 2
+HEADER_SIZE = 10
+ANNOUNCE_FIXED = HEADER_SIZE + 42  # header + size(4) + chunk(4) + hash(32) + name_len(2)
+
+# The forged file the attacker claims. A different length is enough to miss the
+# receiver's duplicate-ANNOUNCE check and drive the (buggy) re-latch path.
+FORGED_LENGTH = 4096
+FORGED_NAME = b"evil"
+FORGED_HASH = bytes([0xAB]) * 32
+
+
+def is_type(data, wire_type):
+    """True if data is one of our v3 packets of the given type."""
+    return len(data) >= HEADER_SIZE and data[:4] == MAGIC and data[5] == wire_type
+
+
+def build_forged_announce(session):
+    """A well-formed ANNOUNCE reusing `session` but describing a different file."""
+    pkt = bytearray(ANNOUNCE_FIXED + len(FORGED_NAME))
+    pkt[0:4] = MAGIC
+    pkt[4] = 3  # VERSION
+    pkt[5] = TYPE_ANNOUNCE
+    pkt[6:10] = session
+    pkt[10:14] = FORGED_LENGTH.to_bytes(4, "big")   # file_size
+    pkt[14:18] = (1400).to_bytes(4, "big")          # chunk_size (in the valid range)
+    pkt[18:50] = FORGED_HASH                         # sha256
+    pkt[50:52] = len(FORGED_NAME).to_bytes(2, "big")  # name_len
+    pkt[52:52 + len(FORGED_NAME)] = FORGED_NAME
+    return bytes(pkt)
+
+
+def forward_and_hijack(listen_port, target_host, target_port):
+    """Forward sender->receiver traffic, injecting one forged ANNOUNCE mid-flight."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", listen_port))
+    session = None
+    injected = False
+    while True:
+        data, _ = sock.recvfrom(65536)
+        if session is None and is_type(data, TYPE_ANNOUNCE):
+            session = data[6:10]  # sniff the cleartext session id
+        # Forward the real packet untouched first, so the receiver has latched the
+        # session and stored at least one real part before the forgery lands.
+        sock.sendto(data, (target_host, target_port))
+        if not injected and session is not None and is_type(data, TYPE_TRANSFER):
+            forged = build_forged_announce(session)
+            sock.sendto(forged, (target_host, target_port))
+            injected = True
+            print("[hijack] injected forged same-session ANNOUNCE "
+                  f"(session={int.from_bytes(session, 'big'):#010x}, "
+                  f"claimed length={FORGED_LENGTH})", file=sys.stderr)
+
+
+def forward_clean(listen_port, target_host, target_port):
+    """Forward every datagram from listen_port to the target byte-for-byte."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", listen_port))
+    while True:
+        data, _ = sock.recvfrom(65536)
+        sock.sendto(data, (target_host, target_port))
+
+
+def main():
+    """Parse CLI arguments and run the two forwarding threads until killed."""
+    p = argparse.ArgumentParser()
+    p.add_argument("--listen-fwd",  type=int, required=True,
+                   help="Listen port for the sender->receiver direction")
+    p.add_argument("--target-fwd",  type=int, required=True,
+                   help="Where to forward sender->receiver traffic (forged ANNOUNCE injected)")
+    p.add_argument("--listen-back", type=int, required=True,
+                   help="Listen port for the receiver->sender direction")
+    p.add_argument("--target-back", type=int, required=True,
+                   help="Where to forward receiver->sender traffic (untouched)")
+    args = p.parse_args()
+
+    threading.Thread(
+        target=forward_and_hijack,
+        args=(args.listen_fwd, "127.0.0.1", args.target_fwd),
+        daemon=True,
+    ).start()
+    threading.Thread(
+        target=forward_clean,
+        args=(args.listen_back, "127.0.0.1", args.target_back),
+        daemon=True,
+    ).start()
+
+    threading.Event().wait()  # block forever; killed by parent
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hijack_proxy.py
+++ b/tests/hijack_proxy.py
@@ -23,8 +23,11 @@ HEADER_SIZE = 10
 ANNOUNCE_FIXED = HEADER_SIZE + 42  # header + size(4) + chunk(4) + hash(32) + name_len(2)
 
 # The forged file the attacker claims. A different length is enough to miss the
-# receiver's duplicate-ANNOUNCE check and drive the (buggy) re-latch path.
-FORGED_LENGTH = 4096
+# receiver's duplicate-ANNOUNCE check and drive the (buggy) re-latch path. The
+# length and chunk size are overridable so the test can also forge values that
+# would *fail* the receiver's range check (empty file, out-of-range chunk): those
+# must be dropped by the same-session guard before announceValid() turns them into
+# a fatal error -- the one-packet DoS the guard has to close.
 FORGED_NAME = b"evil"
 FORGED_HASH = bytes([0xAB]) * 32
 
@@ -34,22 +37,22 @@ def is_type(data, wire_type):
     return len(data) >= HEADER_SIZE and data[:4] == MAGIC and data[5] == wire_type
 
 
-def build_forged_announce(session):
-    """A well-formed ANNOUNCE reusing `session` but describing a different file."""
+def build_forged_announce(session, forged_length, forged_chunk):
+    """An ANNOUNCE reusing `session` but describing a different (maybe invalid) file."""
     pkt = bytearray(ANNOUNCE_FIXED + len(FORGED_NAME))
     pkt[0:4] = MAGIC
     pkt[4] = 3  # VERSION
     pkt[5] = TYPE_ANNOUNCE
     pkt[6:10] = session
-    pkt[10:14] = FORGED_LENGTH.to_bytes(4, "big")   # file_size
-    pkt[14:18] = (1400).to_bytes(4, "big")          # chunk_size (in the valid range)
+    pkt[10:14] = forged_length.to_bytes(4, "big")   # file_size
+    pkt[14:18] = forged_chunk.to_bytes(4, "big")    # chunk_size
     pkt[18:50] = FORGED_HASH                         # sha256
     pkt[50:52] = len(FORGED_NAME).to_bytes(2, "big")  # name_len
     pkt[52:52 + len(FORGED_NAME)] = FORGED_NAME
     return bytes(pkt)
 
 
-def forward_and_hijack(listen_port, target_host, target_port):
+def forward_and_hijack(listen_port, target_host, target_port, forged_length, forged_chunk):
     """Forward sender->receiver traffic, injecting one forged ANNOUNCE mid-flight."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -64,12 +67,12 @@ def forward_and_hijack(listen_port, target_host, target_port):
         # session and stored at least one real part before the forgery lands.
         sock.sendto(data, (target_host, target_port))
         if not injected and session is not None and is_type(data, TYPE_TRANSFER):
-            forged = build_forged_announce(session)
+            forged = build_forged_announce(session, forged_length, forged_chunk)
             sock.sendto(forged, (target_host, target_port))
             injected = True
             print("[hijack] injected forged same-session ANNOUNCE "
                   f"(session={int.from_bytes(session, 'big'):#010x}, "
-                  f"claimed length={FORGED_LENGTH})", file=sys.stderr)
+                  f"claimed length={forged_length}, chunk={forged_chunk})", file=sys.stderr)
 
 
 def forward_clean(listen_port, target_host, target_port):
@@ -93,11 +96,16 @@ def main():
                    help="Listen port for the receiver->sender direction")
     p.add_argument("--target-back", type=int, required=True,
                    help="Where to forward receiver->sender traffic (untouched)")
+    p.add_argument("--forge-length", type=int, default=4096,
+                   help="file_size claimed by the forged ANNOUNCE (0 = empty, invalid)")
+    p.add_argument("--forge-chunk", type=int, default=1400,
+                   help="chunk_size claimed by the forged ANNOUNCE (out of [64,65507] = invalid)")
     args = p.parse_args()
 
     threading.Thread(
         target=forward_and_hijack,
-        args=(args.listen_fwd, "127.0.0.1", args.target_fwd),
+        args=(args.listen_fwd, "127.0.0.1", args.target_fwd,
+              args.forge_length, args.forge_chunk),
         daemon=True,
     ).start()
     threading.Thread(


### PR DESCRIPTION
## Summary

`handleAnnounce` only rejected ANNOUNCEs from a **different** session. A packet
that reuses our session id but carries a different `file_length`/`chunk_size`
slipped past the duplicate-ANNOUNCE check and reached the re-latch path, which
overwrote `session_id`/`file_length`/`chunk_size`/`expected_hash`/`announced_name`
and called `prepareStorage → openPartFile`, `ftruncate`-ing the `.part` and
clearing the parts bitmap.

## Impact

The 4-byte session id travels in **cleartext** in every broadcast packet
(`Protocol::writeHeader`, bytes 6–9), so any host on the LAN can read it and
forge a packet:

- **Reset / DoS:** one forged datagram wipes an almost-complete transfer — a
  repeatable, single-packet DoS/livelock.
- **Hijack:** because re-latch also replaces `expected_hash` and the file name,
  an attacker who follows up with their own `TRANSFER` + `FINISH` set can make
  injected bytes report **"sha256 verified"** under a chosen name — exactly the
  substitution the different-session gate was meant to prevent. Without re-latch,
  a `TRANSFER` injection could only corrupt (hash fails), not verify.

This is the one path that directly undermines the advertised guarantee that a
corrupted/substituted file is rejected.

## Fix

Once storage is open we are committed to this session's file. Any same-session
ANNOUNCE that differs in `file_length`/`chunk_size`/`hash` is now treated as
hostile: it is logged and dropped, never re-latched. Matching ANNOUNCEs are
still accepted as harmless retransmissions. A sender that genuinely restarts
with a new file draws a fresh session id and is handled by the existing
different-session gate — never reset an active transfer from the network.

## Tests

- New `e2e_hijack` test (`tests/hijack_proxy.py` sniffs the cleartext session id
  and injects one forged same-session ANNOUNCE mid-transfer). It **fails on the
  old code** (receiver times out / exits non-zero after the `.part` is wiped and
  the hash swapped) and **passes with the guard** (forgery refused, real
  transfer verifies, exit 0).
- Full suite green: `ctest --test-dir build` — 7/7 pass.