### PR TITLE
[Security review][L3] Reject pre-planted hardlinks when opening .part files

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,9 @@ The snapshot is deleted once the file completes and its checksum verifies.
   are kept after Ctrl+C or a timeout so a later run can continue. A hard kill
   (SIGKILL) or power loss mid-transfer can still lose the latest unflushed
   progress. The `.part`/`.part.idx` files use stable, predictable names in the
-  working directory, so run the receiver from a directory only you can write to.
+  working directory. The receiver refuses to write through a symlink or a
+  pre-planted hardlink at those names, but still run it from a directory only
+  you can write to.
 - No authentication. Any host on the same LAN can announce a transfer and any
   receiver bound to the chosen port will accept it. The SHA-256 check catches
   accidental corruption, not a deliberately crafted stream.

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -140,6 +140,15 @@ bool closePartFile(bool flush) {
     #endif
 }
 
+#if !defined(_WIN32) && !defined(_WIN64)
+// O_NOFOLLOW rejects a symlink but not a pre-planted hardlink; refuse anything
+// that isn't a lone regular file so our writes can't reach a linked victim.
+bool isLoneRegularFile(int fd) {
+    struct stat st;
+    return fstat(fd, &st) == 0 && S_ISREG(st.st_mode) && st.st_nlink == 1;
+}
+#endif
+
 bool openPartFile(bool reuse_existing) {
     closePartFile(false);
     part_path = snapshotPartPath();
@@ -168,11 +177,15 @@ bool openPartFile(bool reuse_existing) {
         }
     }
     #else
-    int flags = O_RDWR | O_CREAT | O_NOFOLLOW;
-    if (!reuse_existing) flags |= O_TRUNC;
-    part_fd = open(part_path.c_str(), flags, 0644);
+    // No O_TRUNC: it would wipe a pre-planted hardlink's victim before the
+    // isLoneRegularFile guard below could refuse it.
+    part_fd = open(part_path.c_str(), O_RDWR | O_CREAT | O_NOFOLLOW, 0644);
     if (part_fd < 0) return false;
 
+    if (!isLoneRegularFile(part_fd)) {
+        closePartFile(false);
+        return false;
+    }
     if (reuse_existing) {
         struct stat st;
         if (fstat(part_fd, &st) != 0 || st.st_size < 0 ||
@@ -415,8 +428,14 @@ bool writeRawFile(const std::string& path, const char* data, size_t len) {
     out.close();
     return static_cast<bool>(out);
     #else
-    int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0644);
+    // No O_TRUNC: refuse a pre-planted hardlink (isLoneRegularFile) before
+    // truncating, so we can't wipe the linked victim.
+    int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_NOFOLLOW, 0644);
     if (fd < 0) return false;
+    if (!isLoneRegularFile(fd) || ftruncate(fd, 0) != 0) {
+        close(fd);
+        return false;
+    }
     bool ok = true;
     for (size_t off = 0; off < len; ) {
         ssize_t w = write(fd, data + off, len - off);

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -378,6 +378,42 @@ run_timeout_no_sender_test() {
 }
 run_timeout_no_sender_test
 
+# Pre-planted hardlink: O_NOFOLLOW blocks a symlink but not a hardlink, so a
+# local attacker who can write the cwd could hardlink the predictable <name>.part
+# onto a victim file and have the receiver's truncate/writes corrupt it. Plant
+# such a hardlink and assert the receiver refuses (non-zero exit) and leaves the
+# victim's contents byte-for-byte intact.
+run_hardlink_part_test() {
+    local dir="$WORKDIR/hardlink-part"
+    mkdir -p "$dir"
+    dd if=/dev/urandom of="$dir/src.bin" bs=1024 count=50 status=none
+    printf 'precious victim data that must not be truncated' > "$dir/victim"
+    cp "$dir/victim" "$dir/victim.expected"
+    ln "$dir/victim" "$dir/out.bin.part"   # hardlink at the predictable .part name
+
+    echo "==> [hardlink] receive with a hardlinked out.bin.part planted"
+    local rc=0
+    ( cd "$dir" && exec "$BINARY" receive out.bin --to 127.0.0.1 \
+          --bind-port 33417 --port 33418 --ttl 5 --delay-ms 0 > recv.log 2>&1 ) &
+    local rpid=$!
+    sleep 1
+    "$BINARY" send "$dir/src.bin" --to 127.0.0.1 --bind-port 33418 --port 33417 \
+              --ttl 2 --delay-ms 0 > "$dir/send.log" 2>&1 || true
+    wait "$rpid" || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "FAIL: [hardlink] receiver accepted a hardlinked .part (exit 0)"
+        tail -5 "$dir/recv.log"
+        return 1
+    fi
+    if ! cmp -s "$dir/victim.expected" "$dir/victim"; then
+        echo "FAIL: [hardlink] victim file was corrupted through the hardlink"
+        return 1
+    fi
+    echo "PASS: [hardlink] refused the pre-planted hardlink, victim intact"
+}
+run_hardlink_part_test
+
 # Many parts: a tiny MTU splits even a small file into hundreds of parts, so this
 # drives the received-parts bitmap (set/has/count) across a large index range and
 # checks reassembly stays byte-exact. The bitmap replaced an std::set that scaled


### PR DESCRIPTION
## Problem

The receiver creates the in-progress `<name>.part` file with
`O_RDWR | O_CREAT | O_TRUNC | O_NOFOLLOW` (`src/Receiver.cpp`), and the
`.part.idx` snapshot is written the same way. `O_NOFOLLOW` refuses a **symlink**
but does **not** refuse a **hardlink**.

A local attacker with write access to the receiver's working directory can
pre-plant a hardlink at the predictable `<name>.part` (or `<name>.part.idx`)
name, pointing at a victim file they cannot otherwise write. On the fresh path
the `O_TRUNC` at `open()` plus the following `ftruncate()` then destroy the
victim inode's contents, and the received bytes are written straight through the
link. The rest of finalize is carefully symlink-safe, but the hardlink case was
an open hole.

## Fix

- Drop `O_TRUNC` from the fresh `.part` open and from `writeRawFile` — with
  `O_TRUNC` the victim was already truncated at `open()` time, before any check
  could run.
- Add `isLoneRegularFile(fd)` and reject any fd that is not a lone regular file
  (`S_ISREG` + `st_nlink == 1`) **before** truncating or writing, on both the
  `.part` open (fresh and reuse paths) and the `.part.idx` writer. A hardlink to
  a victim the attacker cannot unlink keeps `st_nlink >= 2`, so it is refused.

## Test

Added an e2e case (`run_hardlink_part_test`) that plants a hardlink at the
predictable `out.bin.part` name onto a victim file, runs a real transfer, and
asserts the receiver exits non-zero and the victim is byte-for-byte intact.
Without the fix the victim is truncated and overwritten and the receiver reports
success.

## Verification

- `tests/e2e.sh` — all cases pass, including the new `[hardlink]` case.
- `GTests` — 35/35 pass.
- Manual: receiver exits `1` (`Can't create temporary output file out.bin.part`),
  victim contents unchanged.

## Notes

POSIX-only (hardlinks); the Windows path is unchanged. README Limitations updated
to note the symlink/hardlink refusal while keeping the "run from a directory only
you can write to" advice.
