### PR TITLE
[Security review][L4] Undeliverable datagrams silently strand transfers at large --mtu

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ filecast receive [file] [options]    # receive a file (default: name from sender
 | `--iface`     | system-chosen | IPv4 | Multicast interface — the local NIC's IPv4 to send/receive the group on (`--multicast` only) |
 | `-p, --port`  | `33333`    | 1..65535 | Destination port for outgoing packets |
 | `--bind-port` | `33333`    | 1..65535 | Local port to bind on |
-| `--mtu`       | `1500`     | 64..65507 | Max packet size in bytes |
+| `--mtu`       | `1500`     | 64..65489 | Max packet size in bytes (18-byte header keeps the datagram within the 65507-byte UDP limit) |
 | `--ttl`       | `15`       | > 0 | Seconds of silence before giving up |
 | `--rate`      | `100`      | > 0 | Target send rate in Mbit/s |
 | `--overwrite` | off        | — | Overwrite an existing output file |

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,5 +1,6 @@
 #include "cxxopts.hpp"
 #include "Config.hpp"
+#include "Protocol.hpp"
 
 #include <iostream>
 #include <ostream>
@@ -120,8 +121,10 @@ Command pickCommand(int argc, char* argv[], cxxopts::Options& options, int& exit
 
 // Validate the numeric flags. Prints and returns false on the first bad value.
 bool validateNumericFlags(const CliOptions& opt) {
-    if (opt.mtu < 64 || opt.mtu > 65507) {
-        std::cerr << "Error: --mtu must be between 64 and 65507" << std::endl;
+    if (opt.mtu < static_cast<int>(Protocol::MIN_CHUNK) ||
+        opt.mtu > static_cast<int>(Protocol::MAX_CHUNK)) {
+        std::cerr << "Error: --mtu must be between " << Protocol::MIN_CHUNK
+                  << " and " << Protocol::MAX_CHUNK << std::endl;
         return false;
     }
     if (opt.ttl <= 0) {

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -108,10 +108,14 @@ inline Parse parseHeader(const char* buf, size_t length, Header& h) {
     return (h.version == VERSION) ? Parse::Ok : Parse::BadVersion;
 }
 
+// Largest IPv4 UDP payload; a TRANSFER datagram is TRANSFER_HEADER + chunk, so
+// the chunk must stay TRANSFER_HEADER below it or sendto() hits EMSGSIZE.
+constexpr size_t MAX_UDP_PAYLOAD = 65507;
+
 // Valid chunk size range (the sender's --mtu bounds). The lower bound also caps
 // the part count, so a forged tiny chunk cannot blow up the receiver.
 constexpr size_t MIN_CHUNK = 64;
-constexpr size_t MAX_CHUNK = 65507;
+constexpr size_t MAX_CHUNK = MAX_UDP_PAYLOAD - TRANSFER_HEADER;  // 65489
 
 inline size_t totalParts(size_t file_length, size_t chunk_size) {
     if (chunk_size == 0) return 0;  // guard the reusable helper against misuse

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -15,6 +15,11 @@
 #include <algorithm>
 #include <map>
 #include <random>
+#include <cerrno>
+
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#include <sys/sysctl.h>
+#endif
 
 using namespace std::chrono_literals;
 
@@ -68,9 +73,24 @@ bool sendPart(size_t part_index) {
         return false;
     }
 
-    auto sent = sendto(_socket, buffer, static_cast<int>(packet_length + Protocol::TRANSFER_HEADER), 0,
+    size_t datagram = packet_length + Protocol::TRANSFER_HEADER;
+    auto sent = sendto(_socket, buffer, static_cast<int>(datagram), 0,
                        reinterpret_cast<sockaddr*>(&broadcast_address), sizeof(broadcast_address));
     if (sent < 0) {
+        // EMSGSIZE is permanent (the datagram is too big for this host's UDP
+        // stack); RESEND would loop forever, so fail loudly instead of a silent
+        // broken transfer. Other errors are transient and recoverable via RESEND.
+#if defined(_WIN32) || defined(_WIN64)
+        bool too_big = (WSAGetLastError() == WSAEMSGSIZE);
+#else
+        bool too_big = (errno == EMSGSIZE);
+#endif
+        if (too_big) {
+            std::cerr << "Error: part " << part_index << " needs a " << datagram
+                      << "-byte datagram, over this system's UDP send limit; lower --mtu"
+                      << std::endl;
+            return false;
+        }
         std::cerr << "Warning: Failed to send part " << part_index << std::endl;
         return true;
     }
@@ -247,8 +267,35 @@ bool serveResends(size_t total_parts, size_t& resent) {
     return true;
 }
 
+// Largest UDP datagram this host will actually send. macOS/BSD cap outbound
+// datagrams at net.inet.udp.maxdgram (default 9216); elsewhere the IPv4 payload
+// ceiling applies. Sending past this fails with EMSGSIZE.
+size_t maxSendDatagram() {
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+    int val = 0;
+    size_t len = sizeof(val);
+    if (sysctlbyname("net.inet.udp.maxdgram", &val, &len, nullptr, 0) == 0 && val > 0) {
+        return static_cast<size_t>(val);
+    }
+#endif
+    return Protocol::MAX_UDP_PAYLOAD;
+}
+
 // Returns a process exit code: 0 on success, non-zero on failure.
 int run() {
+    // Reject an --mtu whose datagram the OS won't send before we hash the whole
+    // file. --mtu passes the static IPv4 cap (65489) but a host may allow less.
+    size_t max_dgram = maxSendDatagram();
+    if (static_cast<size_t>(mtu) + Protocol::TRANSFER_HEADER > max_dgram) {
+        size_t max_mtu = (max_dgram > Protocol::TRANSFER_HEADER)
+                       ? max_dgram - Protocol::TRANSFER_HEADER : 0;
+        std::cerr << "Error: --mtu " << mtu << " needs a "
+                  << (static_cast<size_t>(mtu) + Protocol::TRANSFER_HEADER)
+                  << "-byte datagram, over this system's UDP send limit of " << max_dgram
+                  << "; use --mtu <= " << max_mtu << std::endl;
+        return 1;
+    }
+
     buffer = new char[2 * mtu];
 
     if (openInputFile() != 0) {

--- a/tests/Tests.cpp
+++ b/tests/Tests.cpp
@@ -202,11 +202,11 @@ TEST(Protocol, ExpectedPartSize) {
 TEST(Protocol, AnnounceInRange) {
     const size_t maxFile = 4ULL * 1024 * 1024 * 1024;
     EXPECT_TRUE(Protocol::announceInRange(1, 64, maxFile));
-    EXPECT_TRUE(Protocol::announceInRange(maxFile, 65507, maxFile));
+    EXPECT_TRUE(Protocol::announceInRange(maxFile, 65489, maxFile));   // MAX_CHUNK (fits a UDP datagram)
     EXPECT_FALSE(Protocol::announceInRange(0, 1500, maxFile));         // empty file
     EXPECT_FALSE(Protocol::announceInRange(maxFile + 1, 1500, maxFile)); // too big
     EXPECT_FALSE(Protocol::announceInRange(1000, 63, maxFile));        // chunk too small (OOM guard)
-    EXPECT_FALSE(Protocol::announceInRange(1000, 65508, maxFile));     // chunk too big
+    EXPECT_FALSE(Protocol::announceInRange(1000, 65490, maxFile));     // chunk too big (TRANSFER_HEADER would overflow the datagram)
 }
 
 // --- Progress formatting ----------------------------------------------------

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -170,6 +170,37 @@ run_iface_validation() {
 }
 run_iface_validation
 
+# L4 regression: an --mtu whose datagram (chunk + 18-byte header) exceeds the
+# host's UDP send limit must be rejected up front, never reported as a successful
+# (but silently truncated) transfer. macOS/BSD cap outbound datagrams at
+# net.inet.udp.maxdgram (~9216); elsewhere the 65507 IPv4 ceiling applies and the
+# static --mtu cap (65489) bites. Pure validation, so it runs everywhere.
+run_mtu_datagram_limit_test() {
+    local f="$WORKDIR/mtu-src.bin"
+    echo "mtu-test" > "$f"
+    local out=0 err header=18 limit
+    limit="$(sysctl -n net.inet.udp.maxdgram 2>/dev/null || echo 65507)"
+    local too_big=$(( limit - header + 1 ))                       # datagram = limit + 1
+    local deliverable=$(( (limit < 65507 ? limit : 65507) - header ))
+
+    # Oversized: must fail loudly with an --mtu error, never print "Sent ".
+    err="$("$BINARY" send "$f" --to 127.0.0.1 --ttl 1 --delay-ms 0 --mtu "$too_big" 2>&1 || true)"
+    if grep -q "Sent " <<<"$err"; then
+        echo "FAIL: [mtu-limit] oversized --mtu $too_big (datagram $((too_big+header)) > $limit) reported success"; out=1
+    elif ! grep -q -- "--mtu" <<<"$err"; then
+        echo "FAIL: [mtu-limit] oversized --mtu $too_big rejected without an --mtu error: $err"; out=1
+    fi
+
+    # Largest deliverable --mtu must still be accepted.
+    if ! "$BINARY" send "$f" --to 127.0.0.1 --ttl 1 --delay-ms 0 --mtu "$deliverable" >/dev/null 2>&1; then
+        echo "FAIL: [mtu-limit] largest deliverable --mtu $deliverable was rejected"; out=1
+    fi
+
+    [ "$out" -eq 0 ] && echo "PASS: [mtu-limit] oversized --mtu rejected, deliverable --mtu accepted"
+    return "$out"
+}
+run_mtu_datagram_limit_test
+
 # Announced-name delivery: run `receive` with NO output path, so the file must
 # be saved under the name carried in the ANNOUNCE. This is the only test that
 # exercises the name_len/name wire fields — every other case passes an explicit


### PR DESCRIPTION
## Problem (L4)

A TRANSFER datagram is `TRANSFER_HEADER (18) + chunk` bytes. Two compounding issues made a large `--mtu` silently corrupt transfers:

1. **Arithmetic ceiling.** `--mtu` was accepted up to 65507, so `--mtu ∈ [65490, 65507]` produced a 65508…65525-byte datagram — over the 65507-byte IPv4 UDP limit.
2. **Root cause: swallowed send failures.** `sendPart()` treated *any* `sendto()` error as a warning and returned `true`:
   ```cpp
   if (sent < 0) { std::cerr << "Warning: Failed to send part..."; return true; }
   ```
   `EMSGSIZE` is **permanent** (RESEND retries hit the same wall), so the sender "finished" successfully while the receiver got a broken/timed-out transfer.

This bites hard on **macOS/BSD**, where `net.inet.udp.maxdgram` defaults to **9216** — so *any* `--mtu` above ~9198 reproduced the silent-stranding symptom, even after the cap.

**Runtime proof (macOS, before the root-cause fix):** `send --mtu 65489` printed `Sent ... at 625 MiB/s` (success) while the receiver reported `Error: Transfer timed out with 3 part(s) missing`; only the small tail part was delivered.

## Fix

**Cap (arithmetic ceiling):**
- `Protocol`: `MAX_UDP_PAYLOAD = 65507`; `MAX_CHUNK = MAX_UDP_PAYLOAD - TRANSFER_HEADER` (65489).
- `--mtu` bounded to `[MIN_CHUNK, MAX_CHUNK]` via the shared constants.

**Root cause (no more silent success):**
- `sendPart()` now treats `EMSGSIZE`/`WSAEMSGSIZE` as **fatal** (`return false`, clear error); other, transient errors are unchanged and still recoverable via RESEND.
- The sender rejects an oversized `--mtu` **at startup, before hashing the whole file**, by comparing the datagram size against the platform's UDP send limit (`net.inet.udp.maxdgram` on macOS/BSD, else the 65507 IPv4 ceiling), with an actionable message (`use --mtu <= N`).

**Docs & tests:**
- README range updated to `64..65489`.
- Unit test boundary updated (`AnnounceInRange`).
- New e2e regression test: an oversized `--mtu` must be rejected (never reported as sent), and the largest deliverable `--mtu` must still transfer.

## Verification (macOS, after)
- `--mtu 65489` → exits 1: `Error: --mtu 65489 needs a 65507-byte datagram, over this system's UDP send limit of 9216; use --mtu <= 9198`.
- `--mtu 9198` (datagram == 9216 limit) → transfers, sha256 verified; `--mtu 9199` → rejected.
- `--mtu 8000` / `1500` → transfer and verify.
- 35 unit tests pass; new e2e test passes.

Reviewed via an adversarial multi-dimension pass (correctness / portability / edge-cases + tests); no blockers or majors, only cosmetic nits (one of which — a `size_t` underflow in the hint string under a pathological sub-18-byte sysctl — is addressed).