### PR TITLE
[Security review][L6] Use steady_clock for RESEND rate-limiting

### DIFF
--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -225,7 +225,9 @@ bool serveResends(size_t total_parts, size_t& resent) {
         size_t part = Protocol::getU32(buffer + Protocol::HEADER_SIZE);
         if (part >= total_parts) continue;
 
-        auto epoch    = std::chrono::system_clock::now().time_since_epoch();
+        // Monotonic clock: a backward NTP step must not stall RESENDs by making
+        // (duration - sent_part[part]) negative for already-served parts.
+        auto epoch    = std::chrono::steady_clock::now().time_since_epoch();
         int64_t duration = std::chrono::duration_cast<std::chrono::seconds>(epoch).count();
 
         ttl = ttl_max;


### PR DESCRIPTION
## Problem

The post-FINISH RESEND rate-limiter in `serveResends` (`src/Sender.cpp`) stored an absolute **wall-clock** second from `system_clock`:

```cpp
auto epoch    = std::chrono::system_clock::now().time_since_epoch();
int64_t duration = std::chrono::duration_cast<std::chrono::seconds>(epoch).count();
...
if (duration - sent_part[part] >= 1) { ... }        // per-part throttle
if (duration - lastFinishSendTime >= 1) { ... }     // FINISH re-announce
```

A backward NTP correction of `D` seconds makes `duration` jump *down*, so `duration - sent_part[part]` (and `duration - lastFinishSendTime`) goes negative for already-served parts. Those RESENDs stay suppressed for up to `D` seconds — degrading exactly the recovery the sender lingers for after FINISH.

Not attackable and self-healing, but it stalls the resend phase for the duration of the clock step.

## Fix

Use the monotonic `steady_clock` for the rate-limit timestamps. Only differences are compared, so the arbitrary epoch is irrelevant, and monotonicity guarantees clock steps can't make the deltas go negative.

## Testing

- `cmake --build build --target filecast` — builds clean.