### PR TITLE
[Security review][L7] Reject reserved device names with trailing spaces/dots

### DIFF
--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -137,9 +137,11 @@ inline bool announceInRange(size_t announced, size_t chunk, size_t maxFile) {
 // an extension — opening it writes to a device, not a file.
 inline bool isReservedDeviceName(const std::string& name) {
     std::string stem = name.substr(0, name.find('.'));
-    // Windows strips trailing spaces and dots before matching, so "con ",
-    // "nul.", "com1 ." also resolve to devices.
-    stem.erase(stem.find_last_not_of(" .") + 1);
+    // The extension (everything from the first '.') is already dropped above, so
+    // `stem` holds only the base name and can never contain a dot. Windows also
+    // strips trailing spaces from that base before matching, so "con ", "com1 "
+    // and the "com1 " base of "com1 .txt" still resolve to devices — trim them.
+    stem.erase(stem.find_last_not_of(' ') + 1);
     std::transform(stem.begin(), stem.end(), stem.begin(),
                    [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
     if (stem == "CON" || stem == "PRN" || stem == "AUX" || stem == "NUL") return true;

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -137,6 +137,9 @@ inline bool announceInRange(size_t announced, size_t chunk, size_t maxFile) {
 // an extension — opening it writes to a device, not a file.
 inline bool isReservedDeviceName(const std::string& name) {
     std::string stem = name.substr(0, name.find('.'));
+    // Windows strips trailing spaces and dots before matching, so "con ",
+    // "nul.", "com1 ." also resolve to devices.
+    stem.erase(stem.find_last_not_of(" .") + 1);
     std::transform(stem.begin(), stem.end(), stem.begin(),
                    [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
     if (stem == "CON" || stem == "PRN" || stem == "AUX" || stem == "NUL") return true;

--- a/tests/Tests.cpp
+++ b/tests/Tests.cpp
@@ -154,6 +154,9 @@ TEST(Protocol, SanitizeNameRejectsDangerous) {
     EXPECT_EQ(Protocol::sanitizeName("CON"), "file.out");             // device
     EXPECT_EQ(Protocol::sanitizeName("com1.txt"), "file.out");        // device + ext, any case
     EXPECT_EQ(Protocol::sanitizeName("LPT9"), "file.out");
+    EXPECT_EQ(Protocol::sanitizeName("con "), "file.out");            // trailing space
+    EXPECT_EQ(Protocol::sanitizeName("nul."), "file.out");            // trailing dot
+    EXPECT_EQ(Protocol::sanitizeName("com1 .txt"), "file.out");       // trailing space before ext
 }
 
 TEST(Protocol, SanitizeNameRejectsControlBytes) {

--- a/tests/Tests.cpp
+++ b/tests/Tests.cpp
@@ -155,8 +155,9 @@ TEST(Protocol, SanitizeNameRejectsDangerous) {
     EXPECT_EQ(Protocol::sanitizeName("com1.txt"), "file.out");        // device + ext, any case
     EXPECT_EQ(Protocol::sanitizeName("LPT9"), "file.out");
     EXPECT_EQ(Protocol::sanitizeName("con "), "file.out");            // trailing space
-    EXPECT_EQ(Protocol::sanitizeName("nul."), "file.out");            // trailing dot
+    EXPECT_EQ(Protocol::sanitizeName("aux "), "file.out");            // trailing space, other device
     EXPECT_EQ(Protocol::sanitizeName("com1 .txt"), "file.out");       // trailing space before ext
+    EXPECT_EQ(Protocol::sanitizeName("console.log"), "console.log");  // base "console" is not a device
 }
 
 TEST(Protocol, SanitizeNameRejectsControlBytes) {


### PR DESCRIPTION
## Problem

`isReservedDeviceName` (`src/Protocol.hpp`) compares the name stem byte-for-byte against `CON/PRN/AUX/NUL/COM1-9/LPT1-9`. Windows, however, strips trailing spaces and dots from a filename component *before* resolving it to a device.

The stem is taken as everything before the first `.`, so trailing dots are already dropped when the extension is split off — but a trailing **space** in the base name survives the split, so `con `, `com1 ` and the `com1 ` base of `com1 .txt` sail through `sanitizeName` unchanged even though the OS still opens them as devices.

Impact is limited (only `receive` without an explicit `-f`, and bytes land in `<name>.part` first), but the filter should match Windows' actual matching rules.

## Fix

Trim trailing spaces from the stem before the comparison. Dots need no trimming here — the stem is `name.substr(0, name.find('.'))`, so it can never contain one.

## Tests

Extended `Protocol.SanitizeNameRejectsDangerous` with the trailing-space cases `con `, `aux `, and `com1 .txt`, plus a negative `console.log` asserting a base that merely *starts* with a device prefix is not over-blocked. Full suite passes.
