### PR TITLE
[Security review][L5] Exit non-zero when the sender can't reach the kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,21 @@ if(BUILD_TESTING)
             TIMEOUT 120
         )
 
+        # Send-failure variant: a sibling C shim forces the sender's sendto() to
+        # fail with ENETDOWN, so a total local send failure (network unreachable)
+        # exits non-zero instead of printing "Sent ..." and returning 0.
+        add_library(failsendto SHARED tests/failsendto.c)
+        target_link_libraries(failsendto PRIVATE ${CMAKE_DL_LIBS})
+
+        add_test(
+            NAME e2e_sendfail
+            COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/e2e_sendfail.sh
+        )
+        set_tests_properties(e2e_sendfail PROPERTIES
+            ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;FAILLIB=$<TARGET_FILE:failsendto>"
+            TIMEOUT 120
+        )
+
         # Lossy variant: a Python UDP proxy drops packets in both directions to
         # exercise the RESEND recovery branch. Skipped if Python 3 is missing.
         find_package(Python3 COMPONENTS Interpreter QUIET)

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -54,7 +54,9 @@ bool readFileAt(size_t offset, char* out, size_t len) {
     return static_cast<size_t>(input_file.gcount()) == len;
 }
 
-bool sendPart(size_t part_index) {
+// false = fatal read error; a failed send sets *delivered = false instead so the
+// caller can distinguish an all-failed transfer from ordinary UDP loss.
+bool sendPart(size_t part_index, bool* delivered = nullptr) {
     size_t offset        = part_index * static_cast<size_t>(mtu);
     size_t packet_length = file_length - offset;
     if (packet_length > static_cast<size_t>(mtu)) packet_length = static_cast<size_t>(mtu);
@@ -74,6 +76,7 @@ bool sendPart(size_t part_index) {
         std::cerr << "Warning: Failed to send part " << part_index << std::endl;
         return true;
     }
+    if (delivered) *delivered = true;
     if (verbose) {
         std::cout << "Part " << part_index << " with size " << packet_length << " was sent" << std::endl;
     }
@@ -164,13 +167,21 @@ bool sendAnnounce() {
     memcpy(buffer + Protocol::ANNOUNCE_FIXED, name.data(), name.size());
     int announce_len = static_cast<int>(Protocol::ANNOUNCE_FIXED + name.size());
 
+    int announce_sent = 0;
     for (int i = 0; i < 3; ++i) {
         if (sendto(_socket, buffer, announce_len, 0,
                    reinterpret_cast<sockaddr*>(&broadcast_address),
                    sizeof(broadcast_address)) < 0) {
             std::cerr << "Warning: Failed to send ANNOUNCE" << std::endl;
+        } else {
+            ++announce_sent;
         }
         if (i + 1 < 3) pace();
+    }
+    // All ANNOUNCEs rejected locally: no receiver can start, so fail.
+    if (announce_sent == 0) {
+        std::cerr << "Error: Failed to send ANNOUNCE; the network is unreachable" << std::endl;
+        return false;
     }
     if (verbose) {
         std::cout << "Ok: Sent information about new file with size " << file_length << std::endl;
@@ -272,18 +283,30 @@ int run() {
     reporter.start("Sending " + name, file_length, verbose);
 
     size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
+    size_t delivered_parts = 0;
     for (size_t part_index = 0; part_index < total_parts; ++part_index) {
-        if (!sendPart(part_index)) {
+        bool delivered = false;
+        if (!sendPart(part_index, &delivered)) {
             reporter.finish();
             delete[] buffer;
             buffer = nullptr;
             input_file.close();
             return 1;
         }
+        if (delivered) ++delivered_parts;
         reporter.update(std::min((part_index + 1) * static_cast<size_t>(mtu), file_length));
         pace();
     }
     reporter.finish();
+
+    // Not one part reached the kernel: a local send failure, not UDP loss.
+    if (delivered_parts == 0) {
+        std::cerr << "Error: Failed to send any data; the network is unreachable" << std::endl;
+        delete[] buffer;
+        buffer = nullptr;
+        input_file.close();
+        return 1;
+    }
 
     double secs = reporter.elapsed();
     double rate = secs > 0 ? file_length / secs : 0;

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <chrono>
 #include <cstring>
+#include <cerrno>
 #include <cstdio>
 #include <cstdint>
 #include <string>
@@ -55,8 +56,10 @@ bool readFileAt(size_t offset, char* out, size_t len) {
 }
 
 // false = fatal read error; a failed send sets *delivered = false instead so the
-// caller can distinguish an all-failed transfer from ordinary UDP loss.
-bool sendPart(size_t part_index, bool* delivered = nullptr) {
+// caller can distinguish an all-failed transfer from ordinary UDP loss. A send
+// failure also records its errno in *send_errno so the caller can name the cause
+// when nothing got through at all.
+bool sendPart(size_t part_index, bool* delivered = nullptr, int* send_errno = nullptr) {
     size_t offset        = part_index * static_cast<size_t>(mtu);
     size_t packet_length = file_length - offset;
     if (packet_length > static_cast<size_t>(mtu)) packet_length = static_cast<size_t>(mtu);
@@ -73,6 +76,7 @@ bool sendPart(size_t part_index, bool* delivered = nullptr) {
     auto sent = sendto(_socket, buffer, static_cast<int>(packet_length + Protocol::TRANSFER_HEADER), 0,
                        reinterpret_cast<sockaddr*>(&broadcast_address), sizeof(broadcast_address));
     if (sent < 0) {
+        if (send_errno) *send_errno = errno;
         std::cerr << "Warning: Failed to send part " << part_index << std::endl;
         return true;
     }
@@ -168,10 +172,12 @@ bool sendAnnounce() {
     int announce_len = static_cast<int>(Protocol::ANNOUNCE_FIXED + name.size());
 
     int announce_sent = 0;
+    int send_errno = 0;
     for (int i = 0; i < 3; ++i) {
         if (sendto(_socket, buffer, announce_len, 0,
                    reinterpret_cast<sockaddr*>(&broadcast_address),
                    sizeof(broadcast_address)) < 0) {
+            send_errno = errno;
             std::cerr << "Warning: Failed to send ANNOUNCE" << std::endl;
         } else {
             ++announce_sent;
@@ -180,7 +186,8 @@ bool sendAnnounce() {
     }
     // All ANNOUNCEs rejected locally: no receiver can start, so fail.
     if (announce_sent == 0) {
-        std::cerr << "Error: Failed to send ANNOUNCE; the network is unreachable" << std::endl;
+        std::cerr << "Error: Failed to send ANNOUNCE: " << std::strerror(send_errno)
+                  << "; no receiver can start" << std::endl;
         return false;
     }
     if (verbose) {
@@ -284,9 +291,10 @@ int run() {
 
     size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
     size_t delivered_parts = 0;
+    int send_errno = 0;
     for (size_t part_index = 0; part_index < total_parts; ++part_index) {
         bool delivered = false;
-        if (!sendPart(part_index, &delivered)) {
+        if (!sendPart(part_index, &delivered, &send_errno)) {
             reporter.finish();
             delete[] buffer;
             buffer = nullptr;
@@ -301,7 +309,8 @@ int run() {
 
     // Not one part reached the kernel: a local send failure, not UDP loss.
     if (delivered_parts == 0) {
-        std::cerr << "Error: Failed to send any data; the network is unreachable" << std::endl;
+        std::cerr << "Error: Failed to send any data: " << std::strerror(send_errno)
+                  << "; nothing reached the network" << std::endl;
         delete[] buffer;
         buffer = nullptr;
         input_file.close();

--- a/tests/e2e_sendfail.sh
+++ b/tests/e2e_sendfail.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Send-failure end-to-end test: run a sender, but preload a shim
+# (tests/failsendto) that forces sendto() to fail with ENETDOWN — exactly what a
+# downed interface / unreachable network does locally. A total local send
+# failure is distinguishable from ordinary UDP loss (the packet never reaches
+# the kernel), so the sender must report it and exit non-zero rather than print
+# "Sent ..." and return 0, which would let `filecast send f && next` proceed as
+# if the file had gone out.
+#
+# Two branches are covered:
+#   * FAILSENDTO_TYPE=0 fails every packet  -> all ANNOUNCEs fail (sendAnnounce)
+#   * FAILSENDTO_TYPE=2 fails only TRANSFER -> ANNOUNCE goes out but no part does
+#
+# No receiver is involved: the fault is injected locally in the sender.
+#
+# Run via:
+#   ctest --test-dir build --output-on-failure
+#
+# Or directly:
+#   BINARY=build/filecast FAILLIB=build/libfailsendto.so bash tests/e2e_sendfail.sh
+#
+set -euo pipefail
+
+BINARY="${BINARY:-./filecast}"
+FAILLIB="${FAILLIB:-}"
+
+if [ ! -x "$BINARY" ]; then
+    echo "Error: $BINARY not found or not executable. Build first." >&2
+    exit 1
+fi
+if [ -z "$FAILLIB" ] || [ ! -f "$FAILLIB" ]; then
+    echo "Error: FAILLIB ($FAILLIB) not found; build the failsendto shim first." >&2
+    exit 1
+fi
+
+case "$(uname -s)" in
+    Darwin) PRELOAD_VAR="DYLD_INSERT_LIBRARIES" ;;
+    *)      PRELOAD_VAR="LD_PRELOAD" ;;
+esac
+
+# Waive only ASan's "runtime does not come first" guard for the preloaded shim
+# (see tests/e2e_diskfull.sh); every other ASan check stays active.
+SEND_ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}verify_asan_link_order=0"
+
+WORKDIR="$(mktemp -d -t fb-e2e-sendfail.XXXXXX)"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+SRC="$WORKDIR/src.bin"
+dd if=/dev/urandom of="$SRC" bs=1024 count=20 status=none
+
+# Args: label, FAILSENDTO_TYPE value, expected stderr substring
+run_sendfail_test() {
+    local label="$1"
+    local fail_type="$2"
+    local expect="$3"
+    local log="$WORKDIR/$label.log"
+
+    echo "==> [$label] sending with sendto->ENETDOWN (FAILSENDTO_TYPE=$fail_type)"
+    local rc=0
+    env "$PRELOAD_VAR=$FAILLIB" ASAN_OPTIONS="$SEND_ASAN_OPTIONS" FAILSENDTO_TYPE="$fail_type" \
+        "$BINARY" send "$SRC" --to 127.0.0.1 \
+                  --bind-port 33712 --port 33711 \
+                  --ttl 5 --delay-ms 0 > "$log" 2>&1 || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "FAIL: [$label] sender exited 0 despite every send failing"
+        echo "--- sender log (tail):"; tail -20 "$log"
+        return 1
+    fi
+    if ! grep -q "$expect" "$log"; then
+        echo "FAIL: [$label] sender did not report the send failure (expected '$expect')"
+        echo "--- sender log (tail):"; tail -20 "$log"
+        return 1
+    fi
+    echo "PASS: [$label] send failure reported (exit $rc, '$expect')"
+}
+
+# Every packet fails: the ANNOUNCE never leaves the host, so no receiver can start.
+run_sendfail_test "sendfail-announce"  0 "Failed to send ANNOUNCE"
+# ANNOUNCE goes out but every data part is rejected by the kernel.
+run_sendfail_test "sendfail-transfer"  2 "Failed to send any data"
+
+echo
+echo "All send-failure E2E tests passed."

--- a/tests/failsendto.c
+++ b/tests/failsendto.c
@@ -1,0 +1,85 @@
+/*
+ * Fault-injection shim that forces sendto(2) to fail with ENETDOWN, so a test
+ * can drive filecast's sender into its "the network is unreachable" branches
+ * without taking a real interface down (which would need root and would break
+ * loopback for the rest of the suite).
+ *
+ * The sender's only sendto() callers are the packet broadcasts in Sender.cpp
+ * (ANNOUNCE, TRANSFER, FINISH); socket setup uses bind()/setsockopt(). The shim
+ * matches on the filecast header (magic "FCST"(4) + version(1) + type(1)) so it
+ * only ever fails our own datagrams. FAILSENDTO_TYPE (env) selects which packet
+ * type fails: 0 (default) fails every filecast packet — exercising the
+ * all-ANNOUNCE-failed path — while 2 fails only TRANSFER packets, letting the
+ * ANNOUNCE through so the transfer-loop "sent nothing" path is hit instead.
+ *
+ * Written in C for the same reason as tests/failpwrite.c: the sanitizer CI job
+ * instruments C++ only, so the shim preloads cleanly ahead of the ASan runtime.
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+typedef ssize_t (*sendto_fn)(int, const void*, size_t, int,
+                             const struct sockaddr*, socklen_t);
+
+/* -1 = threshold not yet read from the environment. */
+static int g_target = -1;
+
+static int target(void) {
+    if (g_target == -1) {
+        const char* e = getenv("FAILSENDTO_TYPE");  /* Flawfinder: ignore (test-only knob) */
+        g_target = (e && *e) ? (int)strtol(e, NULL, 10) : 0;
+    }
+    return g_target;
+}
+
+/* filecast header: magic "FCST"(4) + version(1) + type(1) at offset 5. */
+static int should_fail(const void* buf, size_t len) {
+    const unsigned char* p = (const unsigned char*)buf;
+    if (len < 6 || memcmp(p, "FCST", 4) != 0) return 0;
+    int t = target();
+    return t == 0 || (int)p[5] == t;
+}
+
+/*
+ * Call the real sendto(). On macOS the __interpose tuple below already pairs us
+ * with the genuine symbol, so referencing sendto() here reaches libc directly;
+ * dlsym(RTLD_NEXT) would instead resolve back to this shim and tail-recurse.
+ * On Linux our exported sendto() shadows libc's, so RTLD_NEXT is required.
+ */
+static ssize_t call_real(int fd, const void* buf, size_t len, int flags,
+                         const struct sockaddr* dst, socklen_t dlen) {
+#if defined(__APPLE__)
+    return sendto(fd, buf, len, flags, dst, dlen);
+#else
+    static sendto_fn real = NULL;
+    if (!real) real = (sendto_fn)dlsym(RTLD_NEXT, "sendto");
+    return real(fd, buf, len, flags, dst, dlen);
+#endif
+}
+
+static ssize_t injected_sendto(int fd, const void* buf, size_t len, int flags,
+                               const struct sockaddr* dst, socklen_t dlen) {
+    if (should_fail(buf, len)) {
+        errno = ENETDOWN;
+        return -1;
+    }
+    return call_real(fd, buf, len, flags, dst, dlen);
+}
+
+#if defined(__APPLE__)
+__attribute__((used, section("__DATA,__interpose")))
+static const void* interpose_sendto[2] = {
+    (const void*)&injected_sendto,
+    (const void*)&sendto,
+};
+#else
+ssize_t sendto(int fd, const void* buf, size_t len, int flags,
+               const struct sockaddr* dst, socklen_t dlen) {
+    return injected_sendto(fd, buf, len, flags, dst, dlen);
+}
+#endif


### PR DESCRIPTION
## Problem

`filecast send` reported success even when every packet failed to leave the host.

`sendPart` treated a failed `sendto()` as a warning and returned `true`, and `sendAnnounce` did the same for all three ANNOUNCE retries. So when the interface was down or the route was unreachable (`ENETDOWN`, `ENOBUFS`, …) the sender still printed `Sent <file> …` and `run()` returned `0`. A script like `filecast send f && next-step` would then proceed as if the file had gone out.

Ignoring *partial* UDP loss is correct — the receiver recovers via RESEND. But an **all-failed** send is different: the packet never even reaches the kernel, so it's locally detectable and should be surfaced.

## Fix

- `sendAnnounce()` now counts successful sends and returns `false` (fatal) if **all three** ANNOUNCEs are rejected — no receiver could ever start.
- The transfer loop in `run()` tracks how many parts actually reached the kernel and exits non-zero if **not a single** part was accepted.
- `sendPart` reports delivery through an optional out-param; a lone send failure stays a non-fatal warning, so partial loss still succeeds with exit `0`.
- `sendFinish` is left as a warning (the data has already gone out by then).

## Tests

- New fault-injection shim `tests/failsendto.c` forces `sendto()` to fail with `ENETDOWN` (matched on the filecast header, so only our datagrams are affected). `FAILSENDTO_TYPE` selects the packet type to drop.
- New `tests/e2e_sendfail.sh` (wired into CTest as `e2e_sendfail`) covers both branches: all-ANNOUNCE-failed and ANNOUNCE-ok-but-no-part-sent, asserting a non-zero exit and the right diagnostic.
- Full suite green locally (`ctest`): `unit`, `e2e`, `e2e_diskfull`, `e2e_syncfail`, `e2e_sendfail`, `e2e_lossy`, `e2e_corrupt`. The `e2e_lossy` test confirms partial loss still exits `0`.
