### PR TITLE
[Security review][L1] Bound the receive wait and resend phase on a wall-clock deadline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,8 +160,21 @@ if(BUILD_TESTING)
                 ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE}"
                 TIMEOUT 120
             )
+
+            # Flood variant: a Python UDP flooder keeps the socket busy so
+            # recvfrom never reports an idle read, pinning that the receiver's
+            # wait and the sender's resend phase now time out on a wall-clock
+            # deadline instead of being kept alive forever. Also needs Python 3.
+            add_test(
+                NAME e2e_flood
+                COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/e2e_flood.sh
+            )
+            set_tests_properties(e2e_flood PROPERTIES
+                ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE}"
+                TIMEOUT 120
+            )
         else()
-            message(STATUS "Python 3 not found — skipping e2e_lossy and e2e_corrupt tests")
+            message(STATUS "Python 3 not found — skipping e2e_lossy, e2e_corrupt, e2e_hijack and e2e_flood tests")
         endif()
     endif()
 endif()

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -59,6 +59,23 @@ bool     have_session = false;
 // mismatch no longer live-locks the transfer.
 size_t chunk_size = 0;
 
+// Wall-clock deadline for the current wait, refreshed only by a recognised packet
+// from our sender (ANNOUNCE/TRANSFER/FINISH for our session). Deciding the timeout
+// on elapsed real time — rather than on how long a single recvfrom sat idle — is
+// what keeps it reachable: a host that floods the socket with junk faster than the
+// 1s SO_RCVTIMEO never lets recvfrom report an idle read, but junk never pushes
+// this deadline either, so the receiver still gives up ttl_max seconds after the
+// last real packet. Steady clock, so a system-time jump cannot move it.
+std::chrono::steady_clock::time_point receive_deadline;
+
+void refreshDeadline() {
+    receive_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(ttl_max);
+}
+
+bool deadlineExpired() {
+    return std::chrono::steady_clock::now() >= receive_deadline;
+}
+
 // A packet with our magic but a foreign protocol version is dropped; report it
 // once per run so a version-mixed LAN is diagnosable without a warning storm.
 void warnVersionOnce(uint8_t seen) {
@@ -666,6 +683,12 @@ int checkParts() {
 
     size_t total = totalParts();
 
+    // Recovery runs its own per-round ttl countdown (a round with no new part
+    // counts down; a recovered part refreshes it). The main receive loop now waits
+    // on a wall-clock deadline instead of this counter, so start recovery with a
+    // full budget rather than inheriting whatever the main loop happened to leave.
+    ttl = ttl_max;
+
     while (ttl && parts.size() < total) {
         if (g_interrupted) return onInterrupt(buffer);
         // Re-request every still-missing part. Walking the bitmap in place avoids
@@ -814,9 +837,9 @@ bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incomin
     if (static_cast<size_t>(length) < Protocol::ANNOUNCE_FIXED + name_len) return true;  // truncated
 
     // Storage open means we are committed to this session's file. Drop a differing
-    // same-session ANNOUNCE before announceValid() and the ttl refresh, so a forged
+    // same-session ANNOUNCE before announceValid() and the deadline refresh, so a forged
     // empty/oversized one can neither fail validation and kill the receiver nor
-    // hold it open. A matching one just refreshes ttl; a restart draws a new session.
+    // hold it open. A matching one just pushes the deadline out; a restart draws a new session.
     if (storage_ready) {
         bool same = announced == file_length && incoming_cs == chunk_size &&
                     memcmp(expected_hash, buf + Protocol::HEADER_SIZE + 8, 32) == 0;
@@ -825,15 +848,15 @@ bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incomin
                       << std::endl;
             return true;
         }
-        ttl = ttl_max;
+        refreshDeadline();
         return true;
     }
 
-    // Only a recognised packet from our sender refreshes ttl. Unrecognised
+    // Only a recognised packet from our sender pushes the timeout out. Unrecognised
     // traffic (stray broadcasts, other receivers' RESENDs, garbage) deliberately
-    // does not, so the timeout stays reachable and a hostile or noisy host cannot
+    // does not, so the deadline stays reachable and a hostile or noisy host cannot
     // keep the receiver alive forever.
-    ttl = ttl_max;
+    refreshDeadline();
 
     if (!announceValid(announced, incoming_cs, exit_code)) return false;
 
@@ -869,7 +892,7 @@ bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incomin
 // ANNOUNCE (a one-packet unauthenticated DoS).
 void handleFinish(uint32_t incoming_sid, bool& finish) {
     if (!have_session || incoming_sid != session_id) return;
-    ttl = ttl_max;
+    refreshDeadline();
     if (!finish) {
         if (verbose) std::cout << "Server finished transferring" << std::endl;
         finish = true;
@@ -898,7 +921,7 @@ int dispatchPacket(char*& buf, size_t& bufcap, int64_t length, bool& finish) {
             break;
         }
         case Protocol::Type::Transfer:
-            if (storage_ready && handleTransfer(buf, length)) ttl = ttl_max;
+            if (storage_ready && handleTransfer(buf, length)) refreshDeadline();
             if (storage_failed) return 2;
             break;
         case Protocol::Type::Finish:
@@ -926,7 +949,8 @@ int run() {
         std::cerr << "Waiting for a sender... (Ctrl+C to cancel)" << std::endl;
     }
 
-    while (ttl > 0) {
+    refreshDeadline();
+    while (!deadlineExpired()) {
         if (g_interrupted) return onInterrupt(buffer);
         // Sender finished transferring — move to the recovery phase (or bail if
         // we joined too late to ever have received the ANNOUNCE).
@@ -944,9 +968,10 @@ int run() {
                                reinterpret_cast<sockaddr*>(&server_address),
                                &server_address_length);
 
-        // Timeout (SO_RCVTIMEO) or socket error: count down toward giving up.
+        // Timeout (SO_RCVTIMEO) or socket error: nothing to process this round. The
+        // wall-clock deadline — not this idle tick — decides when to give up, so a
+        // socket kept busy with junk can no longer starve the countdown.
         if (length < 0) {
-            ttl--;
             continue;
         }
         // A zero-length datagram is a valid UDP event; ignore it. Using the
@@ -963,9 +988,9 @@ int run() {
             return code;
         }
     }
-    // A Ctrl+C that landed exactly as ttl hit 0 skips the top-of-loop check
-    // (recvfrom's ttl-- dropped ttl to 0 and the while guard exited first), so
-    // re-check here to still take the interrupt path (snapshot + exit 130).
+    // A Ctrl+C that landed exactly as the deadline expired skips the top-of-loop
+    // check (the while guard saw the deadline first), so re-check here to still
+    // take the interrupt path (snapshot + exit 130).
     if (g_interrupted) return onInterrupt(buffer);
 
     // ttl exhausted before FINISH: the transfer did not complete.

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -683,13 +683,12 @@ int checkParts() {
 
     size_t total = totalParts();
 
-    // Recovery runs its own per-round ttl countdown (a round with no new part
-    // counts down; a recovered part refreshes it). The main receive loop now waits
-    // on a wall-clock deadline instead of this counter, so start recovery with a
-    // full budget rather than inheriting whatever the main loop happened to leave.
-    ttl = ttl_max;
+    // Wall-clock deadline (refreshed only by a recovered part), so a junk flood
+    // that keeps recvfrom busy can't freeze recovery the way a per-round counter
+    // would. Recovery still gives up ttl_max seconds after the last real part.
+    refreshDeadline();
 
-    while (ttl && parts.size() < total) {
+    while (!deadlineExpired() && parts.size() < total) {
         if (g_interrupted) return onInterrupt(buffer);
         // Re-request every still-missing part. Walking the bitmap in place avoids
         // materialising a full missing-parts vector, which for a 67M-part file
@@ -714,8 +713,12 @@ int checkParts() {
         memset(&sender_address, 0, sizeof(sender_address));
         addr_len sender_address_length = sizeof(sender_address);
 
-        bool progressed = false;
         while (true) {
+            // Bail on Ctrl+C or the deadline before each read, so a junk flood
+            // that keeps recvfrom busy can't spin the drain loop forever.
+            if (g_interrupted) return onInterrupt(buffer);
+            if (deadlineExpired()) break;
+
             auto length = recvfrom(_socket, buffer, static_cast<int>(bufcap), 0,
                                    reinterpret_cast<sockaddr*>(&sender_address),
                                    &sender_address_length);
@@ -730,19 +733,15 @@ int checkParts() {
                 warnVersionOnce(h.version);
                 continue;
             }
-            if (handleTransfer(buffer, static_cast<int64_t>(length))) progressed = true;
+            // Only a recovered part pushes the deadline; junk and our own
+            // looped-back RESENDs don't, so recovery still terminates.
+            if (handleTransfer(buffer, static_cast<int64_t>(length))) refreshDeadline();
             if (storage_failed) {
                 delete[] buffer;
                 if (!resume) removePartFiles();
                 return 2;
             }
         }
-
-        // A new part refreshes ttl; a round with no progress counts down toward
-        // the timeout. Our own looped-back RESENDs are not TRANSFERs, so a dead
-        // sender still lets recovery terminate instead of livelocking.
-        if (progressed) ttl = ttl_max;
-        else            ttl--;
     }
 
     delete[] buffer;

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -215,16 +215,32 @@ bool sendAnnounce() {
     return true;
 }
 
-// Serve RESEND requests until ttl expires, re-announcing FINISH periodically.
-// Returns false on a fatal read error; reports successful re-sends in `resent`.
+// Absolute ceiling on the whole resend-serving phase, expressed as a multiple of
+// ttl_max. The idle ttl already ends the phase once RESEND requests stop; this is
+// a backstop for a peer (buggy or hostile) that keeps sending valid RESENDs, each
+// of which refreshes ttl and would otherwise keep the sender re-reading the file
+// from disk and re-broadcasting parts without end. It is generous enough for any
+// real LAN recovery yet keeps a single sender run bounded.
+constexpr int RESEND_PHASE_TTL_MULTIPLE = 10;
+
+// Serve RESEND requests until ttl expires or the absolute phase deadline is hit,
+// re-announcing FINISH periodically. Returns false on a fatal read error; reports
+// successful re-sends in `resent`.
 bool serveResends(size_t total_parts, size_t& resent) {
     int64_t lastFinishSendTime = 0;
+
+    // Fixed at phase start and never extended by incoming traffic, so it is always
+    // reached even under a continuous RESEND flood (which keeps recvfrom busy, so
+    // the idle ttl below never counts down). Steady clock, so a wall-clock jump
+    // cannot stretch or collapse it.
+    const auto phase_deadline = std::chrono::steady_clock::now() +
+        std::chrono::seconds(static_cast<int64_t>(ttl_max) * RESEND_PHASE_TTL_MULTIPLE);
 
     SOCKADDR_IN sender_address;
     memset(&sender_address, 0, sizeof(sender_address));
     addr_len sender_address_length = sizeof(sender_address);
 
-    while (ttl) {
+    while (ttl && std::chrono::steady_clock::now() < phase_deadline) {
         // Read into the full buffer (2 * mtu). The socket is bound to the same
         // port we broadcast to, so the OS also delivers copies of our own
         // TRANSFER packets here; on Windows a 100-byte buffer made those
@@ -265,15 +281,21 @@ bool serveResends(size_t total_parts, size_t& resent) {
         auto epoch    = std::chrono::system_clock::now().time_since_epoch();
         int64_t duration = std::chrono::duration_cast<std::chrono::seconds>(epoch).count();
 
-        ttl = ttl_max;
-
-        if (duration - sent_part[part] >= 1) {
+        // Rate-limit re-sends to one per part per second. find() rather than
+        // operator[] so merely being asked about a part we won't re-send this
+        // second does not insert a map node. ttl is refreshed only when a part is
+        // actually re-sent, so a flood of RESENDs for a part already served this
+        // second cannot keep the phase alive without any real work being done —
+        // the absolute deadline above is then what ends it.
+        auto it = sent_part.find(part);
+        if (it == sent_part.end() || duration - it->second >= 1) {
             sent_part[part] = duration;
             if (verbose) {
                 std::cout << "Client requested part of file with index " << part << std::endl;
             }
             if (!sendPart(part)) return false;
             ++resent;
+            ttl = ttl_max;
         }
         // Re-announce completion at most once a second.
         if (duration - lastFinishSendTime >= 1) {

--- a/tests/dropproxy.py
+++ b/tests/dropproxy.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+#
+# One-directional UDP drop-proxy for the recovery-phase flood test
+# (tests/e2e_flood.sh). Listens on IN and forwards every datagram to OUT, except
+# it permanently drops TRANSFER (type=2) packets whose part index % MOD == 0. The
+# dropped parts never reach the receiver and can never heal, so the receiver is
+# forced into — and kept in — the RESEND recovery phase. ANNOUNCE, FINISH, and
+# everything else are forwarded untouched.
+#
+#   dropproxy.py <in_port> <out_host> <out_port> <mod>
+#
+# The receiver's RESENDs go straight to the sender (not through this proxy), so
+# the sender still hears them; its re-sends of the dropped parts pass back through
+# here and are dropped again, keeping those parts permanently missing. That lets
+# the test layer a junk flood on the receive port and prove the recovery drain
+# loop still gives up on its wall-clock deadline instead of spinning forever.
+
+import socket
+import struct
+import sys
+
+MAGIC = b"FCST"
+TYPE_TRANSFER = 2
+HEADER_SIZE = 10  # magic(4) + version(1) + type(1) + session(4); part index at [10:14]
+
+
+def main(argv):
+    if len(argv) < 5:
+        print("usage: dropproxy.py <in_port> <out_host> <out_port> <mod>", file=sys.stderr)
+        return 2
+    in_port, out_host, out_port, mod = int(argv[1]), argv[2], int(argv[3]), int(argv[4])
+
+    r = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    r.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    r.bind(("127.0.0.1", in_port))
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    while True:
+        data, _ = r.recvfrom(65535)
+        if (len(data) >= HEADER_SIZE + 4 and data[:4] == MAGIC
+                and data[5] == TYPE_TRANSFER):
+            part = struct.unpack(">I", data[HEADER_SIZE:HEADER_SIZE + 4])[0]
+            if part % mod == 0:
+                continue  # drop this part permanently
+        s.sendto(data, (out_host, out_port))
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except KeyboardInterrupt:
+        pass  # the test kills us; exit quietly

--- a/tests/e2e_flood.sh
+++ b/tests/e2e_flood.sh
@@ -35,10 +35,14 @@ fi
 WORKDIR="$(mktemp -d -t fb-e2e-flood.XXXXXX)"
 FLOOD_PID=""
 PROC_PID=""
+PROXY_PID=""
+SEND_PID=""
 
 cleanup() {
     if [ -n "$PROC_PID"  ]; then kill "$PROC_PID"  2>/dev/null || true; fi
     if [ -n "$FLOOD_PID" ]; then kill "$FLOOD_PID" 2>/dev/null || true; fi
+    if [ -n "$PROXY_PID" ]; then kill "$PROXY_PID" 2>/dev/null || true; fi
+    if [ -n "$SEND_PID"  ]; then kill "$SEND_PID"  2>/dev/null || true; fi
     rm -rf "$WORKDIR"
 }
 trap cleanup EXIT
@@ -151,8 +155,90 @@ sender_resend_flood() {
     echo "PASS: [sender] stopped at the resend deadline after ${elapsed}s under the flood"
 }
 
+# --- Scenario 3: receiver in RESEND recovery under a junk flood --------------
+# A drop-proxy permanently strands ~1/3 of the parts, so the receiver takes the
+# FINISH, finds parts missing, and enters the recovery phase. A junk flood on the
+# receive port then keeps the recovery drain loop's recvfrom busy. Scenario 1
+# already proves the *main* wait survives a flood; this proves the recovery loop
+# does too — it must still give up on its wall-clock deadline (exit 2, reaching
+# the "part(s) missing" recovery-timeout path) rather than spinning forever, which
+# is what the pre-fix drain loop did (it only broke on an idle recvfrom).
+receiver_recovery_flood() {
+    local px=33605 recv_bind=33606 send_bind=33607
+    local src="$WORKDIR/src-recov.bin"
+    local rlog="$WORKDIR/recv-recov.log"
+
+    dd if=/dev/urandom of="$src" bs=1024 count=60 status=none  # 60 KiB => 40 parts
+
+    echo "==> [recovery] drop-proxy strands ~1/3 of the parts to force recovery"
+    "$PYTHON" "$SCRIPT_DIR/dropproxy.py" "$px" 127.0.0.1 "$recv_bind" 3 \
+        > "$WORKDIR/proxy-recov.log" 2>&1 &
+    PROXY_PID=$!
+    sleep 0.2  # let the proxy bind before the sender broadcasts
+
+    echo "==> [recovery] starting receiver (ttl=4) behind the drop-proxy"
+    "$BINARY" receive "$WORKDIR/out-recov.bin" --to 127.0.0.1 \
+              --bind-port "$recv_bind" --port "$send_bind" --ttl 4 --delay-ms 0 --verbose \
+        > "$rlog" 2>&1 &
+    PROC_PID=$!
+    sleep 0.3
+
+    "$BINARY" send "$src" --to 127.0.0.1 \
+              --bind-port "$send_bind" --port "$px" --ttl 1 --delay-ms 0 \
+        > "$WORKDIR/send-recov.log" 2>&1 &
+    SEND_PID=$!
+
+    # Wait (bounded) for recovery to actually begin, then unleash the flood so it
+    # lands while the receiver is in the recovery drain loop, not the main wait.
+    local started=0 i
+    for ((i = 0; i < 100; i++)); do
+        if grep -q "Request part" "$rlog" 2>/dev/null; then started=1; break; fi
+        sleep 0.05
+    done
+    if [ "$started" -ne 1 ]; then
+        echo "FAIL: [recovery] receiver never entered recovery (test setup issue)"
+        tail -5 "$rlog"
+        return 1
+    fi
+    "$PYTHON" "$SCRIPT_DIR/flood.py" garbage 127.0.0.1 "$recv_bind" 20 \
+        > "$WORKDIR/flood-recov.log" 2>&1 &
+    FLOOD_PID=$!
+
+    # The fix makes recovery give up ~ttl seconds in; allow a wide margin. Without
+    # it the flood keeps the drain loop busy and this budget runs out.
+    local exited
+    exited="$(wait_for_exit 120 "$PROC_PID")"  # up to 12s
+    if [ "$exited" -eq 0 ]; then
+        echo "FAIL: [recovery] receiver wedged in the recovery drain loop under the flood"
+        tail -5 "$rlog"
+        return 1
+    fi
+    local rc=0; wait "$PROC_PID" || rc=$?
+    PROC_PID=""
+    kill "$FLOOD_PID" 2>/dev/null || true; wait "$FLOOD_PID" 2>/dev/null || true
+    FLOOD_PID=""
+    kill "$SEND_PID" "$PROXY_PID" 2>/dev/null || true
+    wait "$SEND_PID" 2>/dev/null || true; wait "$PROXY_PID" 2>/dev/null || true
+    SEND_PID=""; PROXY_PID=""
+
+    if [ "$rc" -ne 2 ]; then
+        echo "FAIL: [recovery] expected timeout exit 2, got $rc"
+        tail -5 "$rlog"
+        return 1
+    fi
+    # "part(s) missing" comes only from the recovery-timeout path, proving the
+    # flood was survived there and not in the main wait.
+    if ! grep -q "part(s) missing" "$rlog"; then
+        echo "FAIL: [recovery] timed out in the wrong phase (not recovery)"
+        tail -5 "$rlog"
+        return 1
+    fi
+    echo "PASS: [recovery] recovery loop timed out under a junk flood instead of hanging"
+}
+
 receiver_garbage_flood
 sender_resend_flood
+receiver_recovery_flood
 
 echo
 echo "All flood E2E tests passed."

--- a/tests/e2e_flood.sh
+++ b/tests/e2e_flood.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Timeout-bound E2E tests: prove that a continuous UDP flood can no longer keep
+# filecast alive forever. Both the receiver's main wait and the sender's
+# resend-serving phase used to key their timeout off "recvfrom sat idle for a
+# second", so any host sending faster than that froze the countdown. They now
+# key off a wall-clock deadline, so a flood still lets them give up.
+#
+# Two scenarios:
+#   * receiver: junk flood -> the receiver must still time out (exit 2).
+#   * sender:   valid RESEND flood -> the sender must still stop at its absolute
+#               resend-phase deadline (exit 0), after actually serving resends.
+#
+# Run via:
+#   ctest --test-dir build --output-on-failure
+#
+# Or directly:
+#   BINARY=build/filecast bash tests/e2e_flood.sh
+#
+set -euo pipefail
+
+BINARY="${BINARY:-./filecast}"
+PYTHON="${PYTHON:-python3}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ ! -x "$BINARY" ]; then
+    echo "Error: $BINARY not found or not executable. Build first." >&2
+    exit 1
+fi
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    echo "Error: $PYTHON not found in PATH; the flooder needs Python 3." >&2
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d -t fb-e2e-flood.XXXXXX)"
+FLOOD_PID=""
+PROC_PID=""
+
+cleanup() {
+    [ -n "$PROC_PID"  ] && kill "$PROC_PID"  2>/dev/null || true
+    [ -n "$FLOOD_PID" ] && kill "$FLOOD_PID" 2>/dev/null || true
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# Wait up to $1 tenths of a second for pid $2 to exit. Prints "1" if it exited,
+# "0" if it is still running when the budget runs out.
+wait_for_exit() {
+    local tenths="$1" pid="$2" i
+    for ((i = 0; i < tenths; i++)); do
+        kill -0 "$pid" 2>/dev/null || { echo 1; return; }
+        sleep 0.1
+    done
+    echo 0
+}
+
+# --- Scenario 1: receiver under a junk flood --------------------------------
+# A receiver waiting for a sender is buried under tiny junk datagrams. None are
+# ours, so it stores nothing; with only a 2s ttl it must still time out (exit 2)
+# well within our budget, rather than being kept alive by the busy socket.
+receiver_garbage_flood() {
+    local recv_bind=33601 send_target=33602
+    local log="$WORKDIR/recv-flood.log"
+
+    echo "==> [receiver] flooding junk at the receive port"
+    "$PYTHON" "$SCRIPT_DIR/flood.py" garbage 127.0.0.1 "$recv_bind" 20 \
+        > "$WORKDIR/flood-recv.log" 2>&1 &
+    FLOOD_PID=$!
+    sleep 0.3  # let the flood ramp up before the receiver binds
+
+    echo "==> [receiver] starting receiver (ttl=2) under the flood"
+    "$BINARY" receive "$WORKDIR/out.bin" --to 127.0.0.1 \
+              --bind-port "$recv_bind" --port "$send_target" --ttl 2 --delay-ms 0 \
+        > "$log" 2>&1 &
+    PROC_PID=$!
+
+    # The fix makes it exit ~ttl seconds in; allow a wide margin for CI jitter.
+    local exited
+    exited="$(wait_for_exit 80 "$PROC_PID")"  # up to 8s
+    if [ "$exited" -eq 0 ]; then
+        echo "FAIL: [receiver] still alive under the flood after 8s (ttl was 2)"
+        tail -5 "$log"
+        return 1
+    fi
+    local rc=0; wait "$PROC_PID" || rc=$?
+    PROC_PID=""
+    kill "$FLOOD_PID" 2>/dev/null || true; wait "$FLOOD_PID" 2>/dev/null || true
+    FLOOD_PID=""
+
+    if [ "$rc" -ne 2 ]; then
+        echo "FAIL: [receiver] expected timeout exit 2, got $rc"
+        tail -5 "$log"
+        return 1
+    fi
+    echo "PASS: [receiver] timed out under a junk flood instead of hanging"
+}
+
+# --- Scenario 2: sender under a valid RESEND flood --------------------------
+# The sender finishes a transfer (no real receiver) and enters its resend phase.
+# A flooder sniffs the sender's cleartext session id and hammers it with valid
+# RESENDs for part 0. Each refreshes the idle ttl, so only the absolute phase
+# deadline can end it. With ttl=1 that deadline is 10s; it must exit (0) well
+# before our budget, having actually served at least one resend.
+sender_resend_flood() {
+    local send_bind=33603 sniff_port=33604
+    local src="$WORKDIR/src-flood.bin"
+    local log="$WORKDIR/send-flood.log"
+
+    dd if=/dev/urandom of="$src" bs=1024 count=50 status=none
+
+    echo "==> [sender] sniffing the session id and flooding RESENDs"
+    "$PYTHON" "$SCRIPT_DIR/flood.py" resend "$sniff_port" 127.0.0.1 "$send_bind" 40 \
+        > "$WORKDIR/flood-send.log" 2>&1 &
+    FLOOD_PID=$!
+    sleep 0.3  # start sniffing before the sender's first ANNOUNCE
+
+    echo "==> [sender] starting sender (ttl=1, resend deadline 10s) under the flood"
+    SECONDS=0
+    "$BINARY" send "$src" --to 127.0.0.1 \
+              --bind-port "$send_bind" --port "$sniff_port" --ttl 1 --delay-ms 0 \
+        > "$log" 2>&1 &
+    PROC_PID=$!
+
+    # Absolute deadline is 10s; give a wide margin. Without it the flood would
+    # keep the resend phase alive indefinitely and this budget would run out.
+    local exited
+    exited="$(wait_for_exit 250 "$PROC_PID")"  # up to 25s
+    if [ "$exited" -eq 0 ]; then
+        echo "FAIL: [sender] still serving resends after 25s — no absolute deadline"
+        tail -5 "$log"
+        return 1
+    fi
+    local elapsed="$SECONDS"
+    local rc=0; wait "$PROC_PID" || rc=$?
+    PROC_PID=""
+    kill "$FLOOD_PID" 2>/dev/null || true; wait "$FLOOD_PID" 2>/dev/null || true
+    FLOOD_PID=""
+
+    if [ "$rc" -ne 0 ]; then
+        echo "FAIL: [sender] expected clean exit 0, got $rc"
+        tail -5 "$log"
+        return 1
+    fi
+    # The flood must have actually driven the resend path, or the test proved
+    # nothing about the deadline that bounds it.
+    if ! grep -q "Re-sent" "$log"; then
+        echo "FAIL: [sender] resend phase was never exercised (flood did not engage)"
+        tail -5 "$log"
+        return 1
+    fi
+    echo "PASS: [sender] stopped at the resend deadline after ${elapsed}s under the flood"
+}
+
+receiver_garbage_flood
+sender_resend_flood
+
+echo
+echo "All flood E2E tests passed."

--- a/tests/e2e_flood.sh
+++ b/tests/e2e_flood.sh
@@ -37,8 +37,8 @@ FLOOD_PID=""
 PROC_PID=""
 
 cleanup() {
-    [ -n "$PROC_PID"  ] && kill "$PROC_PID"  2>/dev/null || true
-    [ -n "$FLOOD_PID" ] && kill "$FLOOD_PID" 2>/dev/null || true
+    if [ -n "$PROC_PID"  ]; then kill "$PROC_PID"  2>/dev/null || true; fi
+    if [ -n "$FLOOD_PID" ]; then kill "$FLOOD_PID" 2>/dev/null || true; fi
     rm -rf "$WORKDIR"
 }
 trap cleanup EXIT

--- a/tests/flood.py
+++ b/tests/flood.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# UDP flooder for the timeout-bound E2E tests (tests/e2e_flood.sh). It keeps a
+# target socket continuously busy so recvfrom never reports an idle read, which
+# is exactly the condition that used to keep filecast's receive/resend loops
+# alive forever. Two modes:
+#
+#   garbage <host> <port> <duration>
+#       Blast tiny junk datagrams at host:port. Each is too short to be one of
+#       our packets (parseHeader -> NotOurs), so a correct receiver ignores them
+#       yet must still time out on its wall-clock deadline.
+#
+#   resend <sniff_port> <target_host> <target_port> <duration>
+#       Listen on sniff_port for the sender's broadcasts to learn its (cleartext)
+#       session id, then flood well-formed RESEND packets for part 0 at
+#       target_host:target_port. A correct sender serves them rate-limited but
+#       still stops at its absolute phase deadline instead of running forever.
+#
+# The flooder exits on its own after <duration> seconds as a backstop, but the
+# test normally kills it once the process under test has exited.
+
+import socket
+import struct
+import sys
+import time
+
+MAGIC = b"FCST"
+VERSION = 3
+TYPE_RESEND = 4
+HEADER_SIZE = 10  # magic(4) + version(1) + type(1) + session(4)
+
+# Burst size between clock checks: large enough to keep the socket buffer full on
+# loopback, small enough that the duration backstop stays responsive.
+BURST = 256
+
+
+def make_resend(session, part):
+    # header + part(4), all big-endian, matching Protocol::writeHeader + putU32.
+    return MAGIC + bytes([VERSION, TYPE_RESEND]) + struct.pack(">II", session, part)
+
+
+def garbage(host, port, duration):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    deadline = time.time() + duration
+    while time.time() < deadline:
+        for _ in range(BURST):
+            try:
+                s.sendto(b"x", (host, port))
+            except OSError:
+                pass  # transient ENOBUFS/EAGAIN under a heavy loopback flood
+
+
+def resend(sniff_port, target_host, target_port, duration):
+    r = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    r.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    r.bind(("", sniff_port))
+    r.settimeout(0.05)
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    session = None
+    deadline = time.time() + duration
+    while time.time() < deadline:
+        # Keep draining the sniff socket so a fresh sender run re-latches the id.
+        try:
+            data, _ = r.recvfrom(65535)
+            if len(data) >= HEADER_SIZE and data[:4] == MAGIC:
+                session = struct.unpack(">I", data[6:10])[0]
+        except socket.timeout:
+            pass
+        except OSError:
+            pass
+        if session is None:
+            continue
+        pkt = make_resend(session, 0)
+        for _ in range(BURST):
+            try:
+                s.sendto(pkt, (target_host, target_port))
+            except OSError:
+                pass
+
+
+def main(argv):
+    if len(argv) < 2:
+        print("usage: flood.py garbage|resend ...", file=sys.stderr)
+        return 2
+    mode = argv[1]
+    try:
+        if mode == "garbage":
+            garbage(argv[2], int(argv[3]), float(argv[4]))
+        elif mode == "resend":
+            resend(int(argv[2]), argv[3], int(argv[4]), float(argv[5]))
+        else:
+            print("unknown mode: " + mode, file=sys.stderr)
+            return 2
+    except KeyboardInterrupt:
+        pass  # the test kills us; exit quietly
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Problem

Both timeout loops decided when to give up from how long a single `recvfrom`
sat idle (`SO_RCVTIMEO` = 1s), not from real elapsed time. Any host sending
faster than once a second kept `recvfrom` returning data, so the idle countdown
never advanced and the loop ran forever. The session id is cleartext in every
broadcast, so a "valid" RESEND flood is as easy to forge as raw junk.

- **Receiver — `Receiver::run`** (`src/Receiver.cpp`): `ttl` decremented only on
  `recvfrom < 0`. A flood of one-byte junk (`parseHeader → NotOurs`, no `ttl`
  change) kept `while (ttl > 0)` alive indefinitely — directly contradicting the
  in-code comment that the timeout "stays reachable". Impact is low (a foreground
  CLI just keeps waiting), but the loop was genuinely unbounded.
- **Sender — `Sender::serveResends`** (`src/Sender.cpp`): `ttl = ttl_max` on *any*
  valid RESEND for our session, before the rate-limit. The only exit was
  `ttl_max` consecutive idle seconds, which a ≥1 RESEND/s flood prevents forever —
  the sender keeps re-reading the file from disk and (in broadcast mode)
  re-broadcasting parts to the whole segment. `sent_part[part]` also used
  `operator[]`, inserting a node for every requested index.

## Fix

Decide both timeouts on a `steady_clock` deadline that only real progress pushes
forward.

- **Receiver**: the main loop waits on `receive_deadline`, refreshed only by a
  recognised packet from our sender (ANNOUNCE/TRANSFER/FINISH for our session).
  Junk never pushes it, so the receiver still gives up `ttl_max` seconds after
  the last real packet. Per-packet transfer semantics (the `ttl_max` budget
  between packets) are unchanged. The recovery loop (`checkParts`) keeps its own
  per-round countdown and now resets it explicitly rather than inheriting the
  main loop's counter.
- **Sender**: `serveResends` gains an absolute phase deadline (`ttl_max * 10`,
  steady clock) fixed at phase start and never extended by incoming traffic, so a
  RESEND flood can no longer keep the phase running without end. `ttl` is now
  refreshed **only when a part is actually re-sent**, and the rate-limit map is
  probed with `find()` instead of `operator[]` so merely being asked about a part
  no longer inserts a node. The map stays bounded by the sender's own
  `total_parts` (its own file), which the attacker cannot inflate, so no hard map
  cap is needed on top of the deadline.

## Tests

`tests/e2e_flood.sh` (+ `tests/flood.py`, registered in CMake, Python-gated like
the other proxy tests):

- **receiver**: a junk flood at the receive port — the receiver (`--ttl 2`) must
  still time out (exit 2) instead of hanging.
- **sender**: a flooder sniffs the sender's cleartext session id and hammers it
  with valid RESENDs — the sender must still stop at its resend deadline
  (exit 0) after actually serving resends.

Both scenarios **hang on the pre-fix binary** (verified against `master`) and
pass on this branch. Full suite (unit + all e2e) passes locally, including under
ASan/UBSan.

## Notes

- Trusted-LAN, low severity: the practical win is that neither loop is unbounded
  anymore. `RESEND_PHASE_TTL_MULTIPLE = 10` (150s at the default `--ttl 15`) is a
  generous backstop for real LAN recovery while keeping a single run finite; it
  scales with the operator's `--ttl`.
- Independent of the session-hijack fix branch; based on `master`.