### PR TITLE
Reject symlinks and hardlinks on Windows when opening .part files

### DIFF
--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -158,8 +158,12 @@ bool closePartFile(bool flush) {
 }
 
 #if defined(_WIN32) || defined(_WIN64)
-// Refuse a reparse point/symlink or hardlink; needs the handle opened with
-// FILE_FLAG_OPEN_REPARSE_POINT and without truncation.
+// Win32 counterpart of the POSIX guard below: refuse a reparse point (symlink or
+// junction) or a hardlink so our writes can't reach a linked victim. Relies on the
+// handle being opened with FILE_FLAG_OPEN_REPARSE_POINT (the link itself) and
+// without truncation. The DIRECTORY bit is defence in depth: CreateFileA without
+// FILE_FLAG_BACKUP_SEMANTICS won't return a directory handle, but rejecting it
+// keeps the guard honest if that ever changes.
 bool isLoneRegularFile(HANDLE h) {
     BY_HANDLE_FILE_INFORMATION info;
     if (!GetFileInformationByHandle(h, &info)) return false;

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -157,7 +157,16 @@ bool closePartFile(bool flush) {
     #endif
 }
 
-#if !defined(_WIN32) && !defined(_WIN64)
+#if defined(_WIN32) || defined(_WIN64)
+// Refuse a reparse point/symlink or hardlink; needs the handle opened with
+// FILE_FLAG_OPEN_REPARSE_POINT and without truncation.
+bool isLoneRegularFile(HANDLE h) {
+    BY_HANDLE_FILE_INFORMATION info;
+    if (!GetFileInformationByHandle(h, &info)) return false;
+    if (info.dwFileAttributes & (FILE_ATTRIBUTE_REPARSE_POINT | FILE_ATTRIBUTE_DIRECTORY)) return false;
+    return info.nNumberOfLinks == 1;
+}
+#else
 // O_NOFOLLOW rejects a symlink but not a pre-planted hardlink; refuse anything
 // that isn't a lone regular file so our writes can't reach a linked victim.
 bool isLoneRegularFile(int fd) {
@@ -173,10 +182,17 @@ bool openPartFile(bool reuse_existing) {
     storage_failed = false;
 
     #if defined(_WIN32) || defined(_WIN64)
-    DWORD disposition = reuse_existing ? OPEN_EXISTING : CREATE_ALWAYS;
+    // OPEN_ALWAYS avoids truncating and FILE_FLAG_OPEN_REPARSE_POINT opens the
+    // link itself, so isLoneRegularFile can refuse it before any write.
+    DWORD disposition = reuse_existing ? OPEN_EXISTING : OPEN_ALWAYS;
     part_handle = CreateFileA(part_path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr,
-                              disposition, FILE_ATTRIBUTE_NORMAL, nullptr);
+                              disposition, FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
     if (part_handle == INVALID_HANDLE_VALUE) return false;
+
+    if (!isLoneRegularFile(part_handle)) {
+        closePartFile(false);
+        return false;
+    }
 
     LARGE_INTEGER pos;
     if (reuse_existing) {

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -414,6 +414,43 @@ run_hardlink_part_test() {
 }
 run_hardlink_part_test
 
+# Pre-planted symlink: O_NOFOLLOW (POSIX) and FILE_FLAG_OPEN_REPARSE_POINT +
+# GetFileInformationByHandle (Windows) already refuse a symlinked <name>.part, so
+# pin that guarantee against regressions. A local attacker who can write the cwd
+# could symlink the predictable .part name onto a victim file and have the
+# receiver's truncate/writes clobber it. Plant such a symlink and assert the
+# receiver refuses (non-zero exit) and leaves the victim byte-for-byte intact.
+run_symlink_part_test() {
+    local dir="$WORKDIR/symlink-part"
+    mkdir -p "$dir"
+    dd if=/dev/urandom of="$dir/src.bin" bs=1024 count=50 status=none
+    printf 'precious victim data that must not be truncated' > "$dir/victim"
+    cp "$dir/victim" "$dir/victim.expected"
+    ln -s "$dir/victim" "$dir/out.bin.part"   # symlink at the predictable .part name
+
+    echo "==> [symlink] receive with a symlinked out.bin.part planted"
+    local rc=0
+    ( cd "$dir" && exec "$BINARY" receive out.bin --to 127.0.0.1 \
+          --bind-port 33419 --port 33420 --ttl 5 --delay-ms 0 > recv.log 2>&1 ) &
+    local rpid=$!
+    sleep 1
+    "$BINARY" send "$dir/src.bin" --to 127.0.0.1 --bind-port 33420 --port 33419 \
+              --ttl 2 --delay-ms 0 > "$dir/send.log" 2>&1 || true
+    wait "$rpid" || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "FAIL: [symlink] receiver accepted a symlinked .part (exit 0)"
+        tail -5 "$dir/recv.log"
+        return 1
+    fi
+    if ! cmp -s "$dir/victim.expected" "$dir/victim"; then
+        echo "FAIL: [symlink] victim file was corrupted through the symlink"
+        return 1
+    fi
+    echo "PASS: [symlink] refused the pre-planted symlink, victim intact"
+}
+run_symlink_part_test
+
 # Many parts: a tiny MTU splits even a small file into hundreds of parts, so this
 # drives the received-parts bitmap (set/has/count) across a large index range and
 # checks reassembly stays byte-exact. The bitmap replaced an std::set that scaled


### PR DESCRIPTION
## Problem

The POSIX receiver already refuses a pre-planted **symlink** (`O_NOFOLLOW`) and **hardlink** (`st_nlink == 1`) at the predictable `<name>.part` path (#32). The Windows path had no equivalent guard: it opened `.part` with `CREATE_ALWAYS` and no reparse-point handling. A local attacker who can write the receiver's working directory could therefore plant a reparse point or hardlink at the predictable `<name>.part` name and:

- redirect the receiver's writes to a victim file, and
- have `CREATE_ALWAYS` **truncate the victim first**.

## Fix

`openPartFile` on Windows now mirrors the POSIX guard:

- `CREATE_ALWAYS` → **`OPEN_ALWAYS`** — never truncates an existing file before it is vetted.
- Open with **`FILE_FLAG_OPEN_REPARSE_POINT`** — opens the link itself, not its target.
- **`isLoneRegularFile(HANDLE)`** via `GetFileInformationByHandle` rejects a reparse point, a directory, or any file with `nNumberOfLinks != 1`, **before any write** — covering both fresh and `--resume` opens.

The check runs on the same handle used for writes, so there is no TOCTOU window between vetting and use.

## Tests

- New `run_symlink_part_test` e2e case, mirroring the existing hardlink test: plants a symlink at `<name>.part`, then asserts the receiver exits non-zero and leaves the victim byte-for-byte intact.
- Full e2e suite + unit tests pass locally on macOS.

> The Windows e2e job is skipped in CI (Winsock `SO_REUSEADDR`), so the new test pins the POSIX half of the guarantee; the Windows guard itself is exercised by the `windows-latest` **compile** job.

## Notes

- README already documents this guarantee platform-agnostically (updated in #32) — this PR makes that statement true on Windows.
- The `FILE_ATTRIBUTE_DIRECTORY` bit in `isLoneRegularFile` is defence in depth (`CreateFileA` without `FILE_FLAG_BACKUP_SEMANTICS` won't return a directory handle); a comment now explains why it stays.
