### PR TITLE
Harden pre-latch ANNOUNCE handling and bound resend/ttl edge cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,8 +173,23 @@ if(BUILD_TESTING)
                 ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE}"
                 TIMEOUT 120
             )
+
+            # Pre-latch variant: two forged ANNOUNCEs (empty file, out-of-range
+            # chunk) are fired at a receiver before the real sender starts. A
+            # receiver that hasn't latched a session yet must ignore them and keep
+            # waiting, then complete the real transfer — pinning that a single
+            # crafted datagram can't kill `receive` in its pre-latch window (the
+            # post-latch case is covered by e2e_hijack). Needs Python 3.
+            add_test(
+                NAME e2e_prelatch
+                COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/e2e_prelatch.sh
+            )
+            set_tests_properties(e2e_prelatch PROPERTIES
+                ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE}"
+                TIMEOUT 120
+            )
         else()
-            message(STATUS "Python 3 not found — skipping e2e_lossy, e2e_corrupt, e2e_hijack and e2e_flood tests")
+            message(STATUS "Python 3 not found — skipping e2e_lossy, e2e_corrupt, e2e_hijack, e2e_flood and e2e_prelatch tests")
         endif()
     endif()
 endif()

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -131,6 +131,13 @@ bool validateNumericFlags(const CliOptions& opt) {
         std::cerr << "Error: --ttl must be greater than 0" << std::endl;
         return false;
     }
+    // Cap it far below where ttl*10 seconds (the sender's resend-phase deadline)
+    // would overflow a steady_clock time_point in nanoseconds. A day of silence is
+    // already orders of magnitude more than any real transfer needs.
+    if (opt.ttl > 86400) {
+        std::cerr << "Error: --ttl must be at most 86400 (24h)" << std::endl;
+        return false;
+    }
     if (opt.port <= 0 || opt.port > 65535) {
         std::cerr << "Error: --port must be between 1 and 65535" << std::endl;
         return false;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -131,9 +131,8 @@ bool validateNumericFlags(const CliOptions& opt) {
         std::cerr << "Error: --ttl must be greater than 0" << std::endl;
         return false;
     }
-    // Cap it far below where ttl*10 seconds (the sender's resend-phase deadline)
-    // would overflow a steady_clock time_point in nanoseconds. A day of silence is
-    // already orders of magnitude more than any real transfer needs.
+    // Cap it so ttl*10s (the sender's resend-phase deadline) can't overflow a
+    // steady_clock time_point; a day of silence is already far more than needed.
     if (opt.ttl > 86400) {
         std::cerr << "Error: --ttl must be at most 86400 (24h)" << std::endl;
         return false;

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -119,7 +119,9 @@ constexpr size_t MAX_CHUNK = MAX_UDP_PAYLOAD - TRANSFER_HEADER;  // 65489
 
 inline size_t totalParts(size_t file_length, size_t chunk_size) {
     if (chunk_size == 0) return 0;  // guard the reusable helper against misuse
-    return (file_length + chunk_size - 1) / chunk_size;
+    // Overflow-safe ceiling division: file_length + chunk_size - 1 would wrap a
+    // 32-bit size_t near the 0xFFFFFFFF wire limit and collapse the count to ~0.
+    return file_length / chunk_size + (file_length % chunk_size != 0 ? 1 : 0);
 }
 
 // Expected payload size of `part`: the full chunk for every part but the last,

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -42,11 +42,8 @@ void installSignalHandlers() {
 #endif
 }
 
-// Hard upper bound imposed by the v3 wire format: file_size is a 4-byte field, so
-// the largest representable size is 2^32 - 1. Written as 0xFFFFFFFF (not 4 GiB) so
-// the constant is exact and still fits size_t on a 32-bit build — 4ULL*1024^3 would
-// wrap to 0 there and make announceInRange reject every non-empty file. Disk-backed
-// storage removes the RAM pressure; representing more needs a protocol bump.
+// Hard upper bound from the v3 wire format's 4-byte file_size field. 0xFFFFFFFF
+// (not 4ULL*1024^3, which wraps to 0 on a 32-bit size_t) keeps the limit exact.
 constexpr size_t MAX_FILE_LENGTH = 0xFFFFFFFFu; // 4 GiB - 1 (v3 wire limit)
 
 // Session the receiver is currently bound to. The sender stamps a random id into
@@ -717,10 +714,8 @@ int checkParts() {
         // would be a 512 MB allocation on top of the registry it came from.
         for (size_t index = 0; index < total; ++index) {
             if (parts.has(index)) continue;
-            // Re-requesting a large missing set — especially with --rate/--delay-ms
-            // pacing each send — can take many seconds. Check the interrupt and the
-            // wall-clock deadline inside the burst too, not just in the outer loop,
-            // so Ctrl+C is honoured promptly and the deadline can't be blown past.
+            // Honour Ctrl+C and the deadline inside the burst too: a large paced
+            // re-request set can otherwise take many unresponsive seconds.
             if (g_interrupted) return onInterrupt(buffer);
             if (deadlineExpired()) break;
             Protocol::writeHeader(buffer, Protocol::Type::Resend, session_id);
@@ -854,24 +849,17 @@ bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incomin
         return true;
     }
 
-    // Validate the announced sizes BEFORE latching or pushing the deadline out. A
-    // forged or garbled ANNOUNCE (empty file, out-of-range chunk) must be ignored
-    // like any other unrecognised traffic — not kill a receiver still waiting for
-    // its real sender, and not keep it alive by refreshing the deadline. This
-    // mirrors the same-session guard above, which already drops a conflicting
-    // ANNOUNCE without exiting; the pre-latch window was the one path that still let
-    // a single crafted packet terminate the receiver. The chunk lower bound also
-    // caps the part count, so a forged tiny chunk cannot balloon the parts bitmap.
+    // Validate BEFORE latching or refreshing the deadline: a forged pre-latch
+    // ANNOUNCE (empty file, out-of-range chunk) must be ignored like any junk, not
+    // exit the receiver or hold it alive. Mirrors the same-session guard above.
     if (!Protocol::announceInRange(announced, incoming_cs, MAX_FILE_LENGTH)) {
         std::cerr << "Warning: ignoring announcement with invalid file/chunk size"
                   << std::endl;
         return true;
     }
 
-    // Only a recognised, valid packet from our sender pushes the timeout out.
-    // Unrecognised traffic (stray broadcasts, other receivers' RESENDs, garbage)
-    // deliberately does not, so the deadline stays reachable and a hostile or noisy
-    // host cannot keep the receiver alive forever.
+    // Only a valid packet from our sender pushes the timeout out, so a noisy or
+    // hostile host cannot keep the receiver alive forever.
     refreshDeadline();
 
     session_id   = incoming_sid;

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -42,10 +42,12 @@ void installSignalHandlers() {
 #endif
 }
 
-// Hard upper bound imposed by the v3 wire format: file_size is a 4-byte field.
-// Disk-backed storage removes the RAM pressure, but v3 still cannot represent
-// anything larger than this without a protocol bump.
-constexpr size_t MAX_FILE_LENGTH = 4ULL * 1024 * 1024 * 1024; // 4 GiB
+// Hard upper bound imposed by the v3 wire format: file_size is a 4-byte field, so
+// the largest representable size is 2^32 - 1. Written as 0xFFFFFFFF (not 4 GiB) so
+// the constant is exact and still fits size_t on a 32-bit build — 4ULL*1024^3 would
+// wrap to 0 there and make announceInRange reject every non-empty file. Disk-backed
+// storage removes the RAM pressure; representing more needs a protocol bump.
+constexpr size_t MAX_FILE_LENGTH = 0xFFFFFFFFu; // 4 GiB - 1 (v3 wire limit)
 
 // Session the receiver is currently bound to. The sender stamps a random id into
 // every packet; we latch it from the first ANNOUNCE and then reject packets
@@ -715,6 +717,12 @@ int checkParts() {
         // would be a 512 MB allocation on top of the registry it came from.
         for (size_t index = 0; index < total; ++index) {
             if (parts.has(index)) continue;
+            // Re-requesting a large missing set — especially with --rate/--delay-ms
+            // pacing each send — can take many seconds. Check the interrupt and the
+            // wall-clock deadline inside the burst too, not just in the outer loop,
+            // so Ctrl+C is honoured promptly and the deadline can't be blown past.
+            if (g_interrupted) return onInterrupt(buffer);
+            if (deadlineExpired()) break;
             Protocol::writeHeader(buffer, Protocol::Type::Resend, session_id);
             Protocol::putU32(buffer + Protocol::HEADER_SIZE, static_cast<uint32_t>(index));
             sendto(_socket, buffer, static_cast<int>(Protocol::RESEND_SIZE), 0,
@@ -769,31 +777,6 @@ int checkParts() {
     if (parts.size() < total) return onRecoveryTimeout(total - parts.size());
 
     return verifyAndWrite();
-}
-
-// Range-check the announced sizes. Prints and sets exit_code on failure.
-bool announceValid(size_t announced, size_t chunk, int& exit_code) {
-    if (announced == 0) {
-        std::cerr << "Error: Sender announced empty file" << std::endl;
-        exit_code = 2;
-        return false;
-    }
-    if (announced > MAX_FILE_LENGTH) {
-        std::cerr << "Error: Sender announced file size " << announced
-                  << " bytes, exceeds limit of " << MAX_FILE_LENGTH << std::endl;
-        exit_code = 2;
-        return false;
-    }
-    // Chunk size must be in the sender's valid --mtu range. The lower bound
-    // matters for safety: parts = file_length / chunk_size, so a forged tiny
-    // chunk would size the received-parts bitmap at multiple billions of bits
-    // and OOM/crash the receiver from two tiny packets.
-    if (chunk < Protocol::MIN_CHUNK || chunk > Protocol::MAX_CHUNK) {
-        std::cerr << "Error: Sender announced invalid chunk size " << chunk << std::endl;
-        exit_code = 2;
-        return false;
-    }
-    return true;
 }
 
 // Grow the receive buffer so it can hold a full chunk for this transfer.
@@ -856,8 +839,8 @@ bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incomin
     if (static_cast<size_t>(length) < Protocol::ANNOUNCE_FIXED + name_len) return true;  // truncated
 
     // Storage open means we are committed to this session's file. Drop a differing
-    // same-session ANNOUNCE before announceValid() and the deadline refresh, so a forged
-    // empty/oversized one can neither fail validation and kill the receiver nor
+    // same-session ANNOUNCE before the range-check and deadline refresh, so a forged
+    // one claiming a different file can neither reset/hijack the active transfer nor
     // hold it open. A matching one just pushes the deadline out; a restart draws a new session.
     if (storage_ready) {
         bool same = announced == file_length && incoming_cs == chunk_size &&
@@ -871,13 +854,25 @@ bool handleAnnounce(char*& buf, size_t& bufcap, int64_t length, uint32_t incomin
         return true;
     }
 
-    // Only a recognised packet from our sender pushes the timeout out. Unrecognised
-    // traffic (stray broadcasts, other receivers' RESENDs, garbage) deliberately
-    // does not, so the deadline stays reachable and a hostile or noisy host cannot
-    // keep the receiver alive forever.
-    refreshDeadline();
+    // Validate the announced sizes BEFORE latching or pushing the deadline out. A
+    // forged or garbled ANNOUNCE (empty file, out-of-range chunk) must be ignored
+    // like any other unrecognised traffic — not kill a receiver still waiting for
+    // its real sender, and not keep it alive by refreshing the deadline. This
+    // mirrors the same-session guard above, which already drops a conflicting
+    // ANNOUNCE without exiting; the pre-latch window was the one path that still let
+    // a single crafted packet terminate the receiver. The chunk lower bound also
+    // caps the part count, so a forged tiny chunk cannot balloon the parts bitmap.
+    if (!Protocol::announceInRange(announced, incoming_cs, MAX_FILE_LENGTH)) {
+        std::cerr << "Warning: ignoring announcement with invalid file/chunk size"
+                  << std::endl;
+        return true;
+    }
 
-    if (!announceValid(announced, incoming_cs, exit_code)) return false;
+    // Only a recognised, valid packet from our sender pushes the timeout out.
+    // Unrecognised traffic (stray broadcasts, other receivers' RESENDs, garbage)
+    // deliberately does not, so the deadline stays reachable and a hostile or noisy
+    // host cannot keep the receiver alive forever.
+    refreshDeadline();
 
     session_id   = incoming_sid;
     have_session = true;

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -249,12 +249,16 @@ bool serveResends(size_t total_parts, size_t& resent) {
         auto result = recvfrom(_socket, buffer, 2 * mtu, 0,
                                reinterpret_cast<sockaddr*>(&sender_address), &sender_address_length);
 
-        // No incoming requests for a while - resend FINISH and decrement ttl.
-        if (result <= 0) {
+        // A timeout (SO_RCVTIMEO) returns < 0: no requests this round, so re-announce
+        // FINISH and count ttl down. A zero-length datagram is a real UDP event, not
+        // silence — ignore it, so a peer spraying empty packets can't drain the
+        // resend phase early (mirrors the receiver's length==0 handling).
+        if (result < 0) {
             ttl--;
             sendFinish();
             continue;
         }
+        if (result == 0) continue;
 
         // The socket hears our own TRANSFER/FINISH broadcasts too; only RESENDs
         // for our session and current protocol version matter here. A foreign

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -362,7 +362,9 @@ int run() {
     Progress::Reporter reporter;
     reporter.start("Sending " + name, file_length, verbose);
 
-    size_t total_parts = (file_length + mtu - 1) / static_cast<size_t>(mtu);
+    // Route through the shared helper so the count stays overflow-safe at the
+    // 0xFFFFFFFF wire limit (a raw file_length + mtu - 1 wraps a 32-bit size_t).
+    size_t total_parts = Protocol::totalParts(file_length, static_cast<size_t>(mtu));
     size_t delivered_parts = 0;
     int send_errno = 0;
     for (size_t part_index = 0; part_index < total_parts; ++part_index) {

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -249,10 +249,9 @@ bool serveResends(size_t total_parts, size_t& resent) {
         auto result = recvfrom(_socket, buffer, 2 * mtu, 0,
                                reinterpret_cast<sockaddr*>(&sender_address), &sender_address_length);
 
-        // A timeout (SO_RCVTIMEO) returns < 0: no requests this round, so re-announce
-        // FINISH and count ttl down. A zero-length datagram is a real UDP event, not
-        // silence — ignore it, so a peer spraying empty packets can't drain the
-        // resend phase early (mirrors the receiver's length==0 handling).
+        // Timeout (< 0): no requests this round, so re-announce FINISH and count ttl
+        // down. A zero-length datagram is a real event, not silence: ignore it so
+        // empty packets can't drain the resend phase early.
         if (result < 0) {
             ttl--;
             sendFinish();

--- a/tests/Tests.cpp
+++ b/tests/Tests.cpp
@@ -192,6 +192,11 @@ TEST(Protocol, TotalPartsBoundaries) {
     EXPECT_EQ(Protocol::totalParts(1500, 1500), 1u);
     EXPECT_EQ(Protocol::totalParts(1501, 1500), 2u);
     EXPECT_EQ(Protocol::totalParts(3000, 1500), 2u);
+    // Max v3 wire file size: file_length + chunk_size must not overflow, or a
+    // 32-bit size_t wraps the count to ~0. A real guard on 32-bit builds; on a
+    // 64-bit size_t it can't overflow, so here it just pins the expected count.
+    EXPECT_EQ(Protocol::totalParts(0xFFFFFFFFu, 64), 67108864u);
+    EXPECT_EQ(Protocol::totalParts(0xFFFFFFFFu, 65489), 65584u);
 }
 
 TEST(Protocol, ExpectedPartSize) {

--- a/tests/e2e_hijack.sh
+++ b/tests/e2e_hijack.sh
@@ -10,8 +10,8 @@
 # Two scenarios run in sequence:
 #   valid   -- the forgery claims a well-formed but conflicting file.
 #   invalid -- the forgery claims an out-of-range chunk size, which would *fail*
-#              announceValid(); the guard must drop it before that check runs, or
-#              the forged packet terminates the receiver -- a one-packet DoS.
+#              the announce range-check; the guard must drop it before that check
+#              runs, or the forged packet terminates the receiver -- a one-packet DoS.
 #
 # Run via:
 #   ctest --test-dir build --output-on-failure
@@ -147,8 +147,8 @@ run_test() {
 }
 
 # A valid-but-conflicting forgery, then one whose out-of-range chunk size would
-# fail announceValid() -- the guard has to drop it before that check to avoid the
-# one-packet DoS.
+# fail the announce range-check -- the guard has to drop it before that check to
+# avoid the one-packet DoS.
 run_test "valid"   4096 1400
 run_test "invalid" 4096 1
 

--- a/tests/e2e_prelatch.sh
+++ b/tests/e2e_prelatch.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Pre-latch ANNOUNCE DoS regression test. Before a receiver has latched a session,
+# a forged ANNOUNCE carrying an invalid file_size/chunk must be IGNORED (the
+# receiver keeps waiting), not terminate it. Previously such a packet drove the
+# receiver straight to exit 2 ("Sender announced empty file"), so a single
+# unauthenticated datagram killed `filecast receive` in the very window it spends
+# "Waiting for a sender..." — a one-packet DoS. The same-session guard already
+# covered the post-latch case (see e2e_hijack.sh); this pins the pre-latch one.
+#
+# The test fires two poison ANNOUNCEs (empty file, out-of-range chunk) at the
+# receiver's port BEFORE the real sender starts, checks the receiver is still
+# alive, then runs a normal transfer and requires it to complete and verify —
+# proving the poison was ignored, not fatal.
+#
+# Run via:
+#   ctest --test-dir build --output-on-failure
+#
+# Or directly:
+#   BINARY=build/filecast bash tests/e2e_prelatch.sh
+#
+set -euo pipefail
+
+BINARY="${BINARY:-./filecast}"
+PYTHON="${PYTHON:-python3}"
+
+if [ ! -x "$BINARY" ]; then
+    echo "Error: $BINARY not found or not executable. Build first." >&2
+    exit 1
+fi
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    echo "Error: $PYTHON not found in PATH; the poison sender needs Python 3." >&2
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d -t fb-e2e-prelatch.XXXXXX)"
+RECV_PID=""
+SEND_PID=""
+cleanup() {
+    if [ -n "$RECV_PID" ]; then kill "$RECV_PID" 2>/dev/null || true; fi
+    if [ -n "$SEND_PID" ]; then kill "$SEND_PID" 2>/dev/null || true; fi
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# Own 338xx port block so ctest -j doesn't collide with the other e2e tests.
+RECV_BIND=33801
+SEND_BIND=33802
+
+# Fire one forged ANNOUNCE (reusing a fixed session id, claiming file_size/chunk)
+# straight at the receiver's port.
+send_poison() {
+    local port="$1" file_size="$2" chunk="$3"
+    "$PYTHON" - "$port" "$file_size" "$chunk" <<'PY'
+import socket, struct, sys
+port, file_size, chunk = int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3])
+# Wire layout from src/Protocol.hpp (v3): magic"FCST"(4) + version(1) + type(1) +
+# session(4) + file_size(4) + chunk_size(4) + sha256(32) + name_len(2) + name.
+pkt  = b"FCST" + struct.pack("!BB", 3, 1) + struct.pack("!I", 0x11223344)
+pkt += struct.pack("!I", file_size) + struct.pack("!I", chunk) + b"\x00" * 32
+name = b"evil"
+pkt += struct.pack("!H", len(name)) + name
+socket.socket(socket.AF_INET, socket.SOCK_DGRAM).sendto(pkt, ("127.0.0.1", port))
+PY
+}
+
+src="$WORKDIR/src.bin"
+dst="$WORKDIR/out.bin"
+recv_log="$WORKDIR/recv.log"
+send_log="$WORKDIR/send.log"
+
+echo "==> generating 200 KiB file"
+dd if=/dev/urandom of="$src" bs=1024 count=200 status=none
+
+echo "==> starting receiver (bind=$RECV_BIND)"
+"$BINARY" receive "$dst" --to 127.0.0.1 \
+          --bind-port "$RECV_BIND" --port "$SEND_BIND" --ttl 10 --delay-ms 0 \
+    > "$recv_log" 2>&1 &
+RECV_PID=$!
+sleep 1  # let it bind and enter the pre-latch "Waiting for a sender..." state
+
+echo "==> firing two poison ANNOUNCEs (empty file, out-of-range chunk) pre-latch"
+send_poison "$RECV_BIND" 0    1500   # empty file      -> must be ignored, not fatal
+send_poison "$RECV_BIND" 4096 1      # out-of-range chunk -> must be ignored, not fatal
+sleep 0.5  # give the receiver time to process them (and, if buggy, to die)
+
+# If the receiver had died on the poison it would be gone now, and the transfer
+# below would never complete — catch it here for a crisp failure message.
+if ! kill -0 "$RECV_PID" 2>/dev/null; then
+    echo "FAIL: receiver exited on a poison ANNOUNCE (pre-latch DoS regression)"
+    tail -20 "$recv_log"
+    exit 1
+fi
+
+echo "==> starting real sender (bind=$SEND_BIND)"
+"$BINARY" send "$src" --to 127.0.0.1 \
+          --bind-port "$SEND_BIND" --port "$RECV_BIND" --ttl 3 --delay-ms 0 \
+    > "$send_log" 2>&1 &
+SEND_PID=$!
+
+rc=0
+wait "$RECV_PID" || rc=$?
+RECV_PID=""
+kill "$SEND_PID" 2>/dev/null || true; wait "$SEND_PID" 2>/dev/null || true; SEND_PID=""
+
+if [ "$rc" -ne 0 ]; then
+    echo "FAIL: expected receiver exit 0 after ignoring poison, got $rc"
+    tail -20 "$recv_log"
+    exit 1
+fi
+if [ ! -f "$dst" ] || ! cmp -s "$src" "$dst"; then
+    echo "FAIL: received file missing or does not match source"
+    tail -20 "$recv_log"
+    exit 1
+fi
+if ! grep -q "sha256 verified" "$recv_log"; then
+    echo "FAIL: receiver did not verify the transfer"
+    tail -20 "$recv_log"
+    exit 1
+fi
+# Proof the poison was actually seen and ignored, not just missed by timing.
+if ! grep -q "ignoring announcement with invalid" "$recv_log"; then
+    echo "FAIL: receiver never logged that it ignored the poison ANNOUNCE"
+    tail -20 "$recv_log"
+    exit 1
+fi
+
+echo "PASS: pre-latch poison ANNOUNCEs ignored; real transfer completed and verified"
+echo
+echo "Pre-latch E2E test passed."

--- a/tests/hijack_proxy.py
+++ b/tests/hijack_proxy.py
@@ -23,8 +23,8 @@ HEADER_SIZE = 10
 ANNOUNCE_FIXED = HEADER_SIZE + 42  # header + size(4) + chunk(4) + hash(32) + name_len(2)
 
 # The forged file the attacker claims. Length/chunk are overridable so the test
-# can also forge values announceValid() rejects (empty file, out-of-range chunk),
-# which the guard must drop before they become a fatal error.
+# can also forge values the announce range-check rejects (empty file, out-of-range
+# chunk), which the same-session guard must drop before that check runs.
 FORGED_NAME = b"evil"
 FORGED_HASH = bytes([0xAB]) * 32
 


### PR DESCRIPTION
## Summary

Five robustness fixes from a pre-release audit. Each was reproduced locally and is covered by a test that runs on Linux/macOS. Build is clean under `-Wall -Wextra`; all 10 `ctest` cases pass.

The headline fix is a one-packet DoS: before a receiver latched a session, a single forged `ANNOUNCE` could kill `filecast receive` while it was still waiting for a sender.

## Fixes

### 🔴 Pre-latch ANNOUNCE DoS (`Receiver.cpp`)
Before a receiver latched a session, a forged `ANNOUNCE` with an invalid `file_size`/`chunk` drove `announceValid()` to a fatal `exit(2)` — so one unauthenticated datagram killed `filecast receive` in the very window it spends *"Waiting for a sender..."*. The post-latch path already guarded against this (see `e2e_hijack`); the pre-latch window did not.

- Validate with the side-effect-free `Protocol::announceInRange()` **before** latching or refreshing the deadline.
- Ignore an invalid pre-latch ANNOUNCE (warn + keep waiting) instead of exiting, mirroring the same-session guard.
- Remove the now-unused `announceValid()`.

**Reproduction:** a single `file_size=0` ANNOUNCE made the receiver exit 2 in ~0.1s; it now logs a warning and waits out its full ttl.

### 🟡 RESEND burst ignored Ctrl+C / deadline (`Receiver.cpp`)
The recovery re-request loop checked `g_interrupted` and the wall-clock deadline only in its outer loop, so re-requesting a large missing set (with `--rate`/`--delay-ms` pacing) left the receiver unresponsive for many seconds. Now checked inside the burst too.

### 🟡 32-bit `size_t` overflow on max-size files (`Receiver.cpp`, `Protocol.hpp`, `Sender.cpp`)
Two overflows on the same 4 GiB boundary, both harmless on a 64-bit `size_t`:
- **`MAX_FILE_LENGTH`**: `4ULL*1024*1024*1024` wraps to `0` on a 32-bit `size_t`, making the receiver reject every non-empty file. Use the exact v3 wire limit `0xFFFFFFFF`, which fits `size_t` on every target.
- **`totalParts()`** *(follow-up from review)*: with the limit fixed a max-size `ANNOUNCE` is now accepted, but `(file_length + chunk_size - 1) / chunk_size` still wraps a 32-bit `size_t` for `file_length` in the top `chunk_size` bytes of the range, collapsing the part count to ~0 — the receiver then rejects every data part (`part >= 0`) and calls the transfer 0/0 complete, and the sender (same inlined expression) ships 0 parts. Switched to overflow-safe ceiling division (`file_length / chunk_size + (remainder != 0)`) in the shared helper, with `Sender` routed through it. Contained by the existing `part >= total` bound, so a correctness bug, not OOB/DoS.

### 🟢 `--ttl` overflow guard (`Main.cpp`)
`--ttl` was only checked for `> 0`; `ttl*10` seconds (the sender's resend-phase deadline) overflows a `steady_clock` time_point in nanoseconds at absurd values. Capped at `86400` (24h).

### 🟢 Zero-length datagram drained the resend phase (`Sender.cpp`)
`serveResends()` treated a zero-length datagram as a timeout (`result <= 0`), letting a peer spraying empty packets drain the resend phase early. Split `result < 0` (timeout) from `result == 0` (ignore), mirroring the receiver's `length == 0` handling.

## Tests
- **New `e2e_prelatch`**: fires two poison ANNOUNCEs (empty file, out-of-range chunk) at a receiver before the real sender starts, checks it survives, then requires the real transfer to complete and verify.
- Updated comments in `e2e_hijack.sh` / `hijack_proxy.py` that referenced the removed `announceValid()`.
- **`TotalPartsBoundaries`** unit test now pins the `0xFFFFFFFF` max-wire-size counts (`64`- and `65489`-byte chunks) — a real regression guard on 32-bit builds, a smoke test on 64-bit.
- `ctest`: 10/10 pass (was 9, plus `e2e_prelatch`).

## Deferred (follow-up issues)
Unbounded `sent_part` growth under a full-loss RESEND storm, and three Windows-only items (`WSAGetLastError` in send diagnostics, `WSAStartup` ordering vs `inet_pton`, symlink guard on `.part.idx`) that need CI/Windows to verify.

