### PR TITLE
Pre-release hardening, doc-sync, and repo hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@
 *.pdb
 
 # Build directories
-build/
+build*/
 out/
 
 # Visual Studio

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Alex
+Copyright (c) 2019-2026 gistrec
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2026 gistrec
+Copyright (c) 2019-2026 Aleksandr Kovalko
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ filecast receive [file] [options]    # receive a file (default: name from sender
 | `-p, --port`  | `33333`    | 1..65535 | Destination port for outgoing packets |
 | `--bind-port` | `33333`    | 1..65535 | Local port to bind on |
 | `--mtu`       | `1500`     | 64..65489 | Max packet size in bytes (18-byte header keeps the datagram within the 65507-byte UDP limit) |
-| `--ttl`       | `15`       | > 0 | Seconds of silence before giving up |
+| `--ttl`       | `15`       | 1..86400 | Seconds of silence before giving up |
 | `--rate`      | `100`      | > 0 | Target send rate in Mbit/s |
 | `--overwrite` | off        | — | Overwrite an existing output file |
 | `--resume`    | off        | — | Resume an interrupted receive from its `.part` snapshot |
@@ -226,17 +226,21 @@ The full wire format lives in [docs/PROTOCOL.md](docs/PROTOCOL.md).
 
 ## Resuming an Interrupted Transfer
 
-If a receive is interrupted with Ctrl+C, or times out with parts still missing,
-the receiver saves what it has to `<name>.part` (plus a `<name>.part.idx` record
-of which parts arrived). Re-run with `--resume` and it picks up where it left
-off — the transfer is matched by the file's SHA-256, so it works even if the
-sender is restarted (a new session):
+Start the receive with `--resume`. If it is then interrupted with Ctrl+C, or
+times out with parts still missing, the receiver keeps what it has in
+`<name>.part` (plus a `<name>.part.idx` record of which parts arrived) instead of
+discarding it, and a re-run picks up where it left off — the transfer is matched
+by the file's SHA-256, so it works even if the sender is restarted (a new
+session):
 
 ```sh
 filecast receive album.zip --resume
 ```
 
-The snapshot is deleted once the file completes and its checksum verifies.
+`--resume` is what enables the snapshot, so it has to be set on the *first* run
+too, not just the retry: a plain `filecast receive` deletes its partial file when
+it is interrupted. The snapshot is removed once the file completes and its
+checksum verifies.
 
 ## Limitations
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -61,10 +61,13 @@ packet-loss recovery, SHA-256 verification, and resume.
 [^filecast-hash]: The SHA-256 is announced over the same unauthenticated
     channel as the data, so it guards against loss and corruption, not
     against a malicious LAN peer — see the Limitations section of the README.
-[^uftp-integrity]: No whole-file hash ([protocol
-    spec](https://uftp-multicast.sourceforge.net/protocol.txt)): integrity
-    relies on NAK-based retransmission, and in encrypted mode (the default
-    since v5.0) every packet is authenticated by the AEAD cipher.
+[^uftp-integrity]: ⚠️ rather than ✅ because there is no application-level
+    whole-file hash ([protocol
+    spec](https://uftp-multicast.sourceforge.net/protocol.txt)): integrity rests
+    on NAK-based retransmission plus UDP checksums, with per-packet cryptographic
+    authentication only when encryption is on. That is the default from v5.0
+    (2020) via the AEAD cipher — as strong as the ✅ tools there — but the 4.x
+    builds some distros still ship leave it off (see [^uftp-crypto]).
 [^udpcast-platforms]: Official Windows binaries exist but were last built in
     December 2021 (v20211207); on macOS it builds from source (portability
     fixes landed in the 2025 release) with no official package.

--- a/src/Protocol.hpp
+++ b/src/Protocol.hpp
@@ -171,9 +171,19 @@ inline bool hasControlChar(const std::string& name) {
     });
 }
 
+// Longest base name the receiver will materialize on disk. It appends the
+// ".part.idx" suffix (9 bytes) to build the resume-snapshot path, and most
+// filesystems cap a single path component at NAME_MAX (255). Keeping the base
+// name at or under this bound means "<name>.part" and "<name>.part.idx" both
+// stay within NAME_MAX, so an otherwise-valid transfer cannot fail open() or
+// rename() with ENAMETOOLONG — whether the long name is legitimate or a crafted
+// over-long ANNOUNCE aimed at a still-waiting receiver.
+constexpr size_t MAX_NAME_LEN = 255 - 9;  // room for the ".part.idx" suffix
+
 // Reduce a sender-supplied name to a safe base name in the working directory:
-// strip directories, and reject traversal, ':' (Windows drive-relative / ADS),
-// control/NUL bytes and reserved device names by falling back to "file.out".
+// strip directories, reject traversal, ':' (Windows drive-relative / ADS),
+// control/NUL bytes and reserved device names by falling back to "file.out",
+// then clamp the length so the ".part"/".part.idx" paths fit NAME_MAX.
 inline std::string sanitizeName(const std::string& raw) {
     size_t slash = raw.find_last_of("/\\");
     std::string name = (slash == std::string::npos) ? raw : raw.substr(slash + 1);
@@ -181,6 +191,7 @@ inline std::string sanitizeName(const std::string& raw) {
     if (name.find(':') != std::string::npos) return "file.out";
     if (hasControlChar(name)) return "file.out";
     if (isReservedDeviceName(name)) return "file.out";
+    if (name.size() > MAX_NAME_LEN) name.resize(MAX_NAME_LEN);
     return name;
 }
 

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -175,11 +175,12 @@ bool sendAnnounce() {
     if (verbose) std::cout << "Ok: sha256 " << Sha256::hex(file_hash) << std::endl;
 
     // Name the receiver saves under unless it was given an explicit output path.
-    // Clamp so the whole ANNOUNCE fits the send buffer (2 * mtu) and the length
-    // field (a byte count well under 2^16).
+    // Clamp so the whole ANNOUNCE fits the send buffer (2 * mtu), the length
+    // field (a byte count well under 2^16), and the receiver's on-disk name cap
+    // (Protocol::MAX_NAME_LEN, which leaves room for the ".part.idx" suffix).
     std::string name = baseName(fileName);
     size_t max_name = static_cast<size_t>(2 * mtu) - Protocol::ANNOUNCE_FIXED;
-    if (max_name > 255) max_name = 255;
+    if (max_name > Protocol::MAX_NAME_LEN) max_name = Protocol::MAX_NAME_LEN;
     if (name.size() > max_name) name.resize(max_name);
 
     Protocol::writeHeader(buffer, Protocol::Type::Announce, session_id);
@@ -301,6 +302,11 @@ bool serveResends(size_t total_parts, size_t& resent) {
             if (!sendPart(part)) return false;
             ++resent;
             ttl = ttl_max;
+            // Pace re-sends on the same clock as the initial pass so --rate (and
+            // --delay-ms) bound the recovery phase too. Without this, a peer that
+            // requests many distinct parts pulls them back at full line rate,
+            // ignoring the sender's chosen rate on a shared LAN.
+            pace();
         }
         // Re-announce completion at most once a second.
         if (duration - lastFinishSendTime >= 1) {

--- a/tests/Tests.cpp
+++ b/tests/Tests.cpp
@@ -160,6 +160,16 @@ TEST(Protocol, SanitizeNameRejectsDangerous) {
     EXPECT_EQ(Protocol::sanitizeName("console.log"), "console.log");  // base "console" is not a device
 }
 
+TEST(Protocol, SanitizeNameClampsLength) {
+    // Clamp to MAX_NAME_LEN so "<name>.part" / "<name>.part.idx" stay within
+    // NAME_MAX; otherwise a legit long name — or a crafted over-long ANNOUNCE —
+    // makes the receiver's open()/rename() fail with ENAMETOOLONG.
+    std::string over(500, 'a');
+    EXPECT_EQ(Protocol::sanitizeName(over).size(), Protocol::MAX_NAME_LEN);
+    std::string exact(Protocol::MAX_NAME_LEN, 'b');
+    EXPECT_EQ(Protocol::sanitizeName(exact), exact);
+}
+
 TEST(Protocol, SanitizeNameRejectsControlBytes) {
     using std::string;
     // Embedded NUL: without this guard the name passes every other check but the


### PR DESCRIPTION
## What & why

A final polish pass before the 1.0 release and marketing launch — three small, self-contained changes. No behavioural regressions; the full unit + e2e suite passes (10/10).

### 1. Bound announced filenames and pace the resend phase (`9236027`)
- `sanitizeName` clamps the base name to a new `Protocol::MAX_NAME_LEN` (`NAME_MAX` minus room for the `.part.idx` suffix). A legitimately long name — or a crafted over-long `ANNOUNCE` aimed at a still-waiting receiver — no longer pushes the on-disk `<name>.part` / `<name>.part.idx` path past `NAME_MAX`, where `open()`/`rename()` would fail with `ENAMETOOLONG`. The sender reuses the same constant instead of a bare `255`. New unit test `Protocol.SanitizeNameClampsLength`.
- `serveResends` now paces re-sent parts on the same clock as the initial pass, so `--rate` / `--delay-ms` govern recovery too rather than letting a peer pull many distinct parts back at full line rate.

### 2. Sync docs with disk-backed storage and enforced ranges (`3651b3c`)
- **README:** `--ttl` range documented as `1..86400` (matches the validation); the resume section now states `--resume` must be set on the *first* receive — it's what enables the `.part` snapshot — resolving a contradiction with the Limitations note.
- **COMPARISON:** the UFTP integrity footnote now explains the ⚠️ mark rather than leaving it to look unfair (no application-level whole-file hash; per-packet auth only when encryption is on, which older 4.x distro builds ship off).

### 3. Ignore all `build*/` directories and refresh the license header (`49d018d`)
- `.gitignore`: `build/` → `build*/`, so `build-asan/`, `build-review/`, `build-verify/` can't be accidentally staged.
- `LICENSE`: refreshed copyright year/owner.

## Not in this PR
The six launch-post drafts under `launch-posts/` all claimed "whole file buffered in RAM", which the disk-backed storage refactor made false (and which underneath understated the tool). They've been corrected locally, but `launch-posts/` is intentionally excluded via `.git/info/exclude`, so those edits aren't part of the repo history.

## Testing
`cmake --build` clean under `-Wall -Wextra` (no warnings); `ctest` 10/10 green — unit tests plus every e2e case, including the loss/flood/hijack/prelatch scenarios that exercise the resend and pre-latch paths touched here.
