### PR TITLE
Harden ANNOUNCE delivery: repeat the announcement beyond the initial burst

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,8 +188,22 @@ if(BUILD_TESTING)
                 ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE}"
                 TIMEOUT 120
             )
+
+            # Lost-ANNOUNCE variant (issue #42): a Python UDP proxy swallows the
+            # sender's whole initial ANNOUNCE burst while letting every DATA
+            # packet through. The receiver must warn about un-announced DATA,
+            # latch from a later re-broadcast, and recover the missed parts via
+            # RESEND — pinning the announce-repeat hardening. Needs Python 3.
+            add_test(
+                NAME e2e_lostannounce
+                COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/e2e_lostannounce.sh
+            )
+            set_tests_properties(e2e_lostannounce PROPERTIES
+                ENVIRONMENT "BINARY=$<TARGET_FILE:filecast>;PYTHON=${Python3_EXECUTABLE}"
+                TIMEOUT 120
+            )
         else()
-            message(STATUS "Python 3 not found — skipping e2e_lossy, e2e_corrupt, e2e_hijack, e2e_flood and e2e_prelatch tests")
+            message(STATUS "Python 3 not found — skipping e2e_lossy, e2e_corrupt, e2e_hijack, e2e_flood, e2e_prelatch and e2e_lostannounce tests")
         endif()
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,11 +189,9 @@ if(BUILD_TESTING)
                 TIMEOUT 120
             )
 
-            # Lost-ANNOUNCE variant (issue #42): a Python UDP proxy swallows the
-            # sender's whole initial ANNOUNCE burst while letting every DATA
-            # packet through. The receiver must warn about un-announced DATA,
-            # latch from a later re-broadcast, and recover the missed parts via
-            # RESEND — pinning the announce-repeat hardening. Needs Python 3.
+            # Lost-ANNOUNCE variant: a Python UDP proxy swallows the sender's
+            # initial ANNOUNCE burst; the receiver must latch from a later
+            # re-broadcast and recover via RESEND. Needs Python 3.
             add_test(
                 NAME e2e_lostannounce
                 COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/tests/e2e_lostannounce.sh

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -34,7 +34,12 @@ these 10 bytes.
 ## Transfer sequence
 
 1. The sender broadcasts an `ANNOUNCE` carrying a random session id, the total
-   file size, the chunk size, the file's SHA-256, and its name.
+   file size, the chunk size, the file's SHA-256, and its name. There is no
+   `RESEND` for the announcement, so the sender repeats it byte-identically — a
+   small initial burst, a few times across the first second of `TRANSFER`
+   traffic, and alongside every periodic `FINISH` re-broadcast — so a receiver
+   that lost the initial copies can still latch late and recover the parts it
+   missed through the ordinary `RESEND` path.
 2. Each receiver latches that session, creates an on-disk `.part` file, and
    clears its part registry. The chunk size is taken from the announcement, so
    sender and receivers never disagree about part boundaries even with

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -86,10 +86,8 @@ void warnVersionOnce(uint8_t seen) {
               << static_cast<int>(Protocol::VERSION) << ")" << std::endl;
 }
 
-// DATA is arriving but no ANNOUNCE has been latched: without this line a lost
-// ANNOUNCE burst is indistinguishable from no sender at all — the receiver sits
-// at "Waiting for a sender..." while silently discarding every packet. Once per
-// run; the sender repeats its ANNOUNCE, so latching late is the expected rescue.
+// Once per run: without it a lost ANNOUNCE burst looks exactly like no sender
+// at all while every DATA packet is silently discarded.
 void warnUnannouncedDataOnce() {
     static bool warned = false;
     if (warned) return;

--- a/src/Receiver.cpp
+++ b/src/Receiver.cpp
@@ -86,6 +86,18 @@ void warnVersionOnce(uint8_t seen) {
               << static_cast<int>(Protocol::VERSION) << ")" << std::endl;
 }
 
+// DATA is arriving but no ANNOUNCE has been latched: without this line a lost
+// ANNOUNCE burst is indistinguishable from no sender at all — the receiver sits
+// at "Waiting for a sender..." while silently discarding every packet. Once per
+// run; the sender repeats its ANNOUNCE, so latching late is the expected rescue.
+void warnUnannouncedDataOnce() {
+    static bool warned = false;
+    if (warned) return;
+    warned = true;
+    std::cerr << "Warning: receiving data without an announcement (was it lost?); "
+                 "waiting for the sender to repeat it" << std::endl;
+}
+
 // SHA-256 of the whole file, announced by the sender and checked after reassembly.
 uint8_t expected_hash[32] = {0};
 
@@ -923,6 +935,7 @@ int dispatchPacket(char*& buf, size_t& bufcap, int64_t length, bool& finish) {
             break;
         }
         case Protocol::Type::Transfer:
+            if (!have_session) warnUnannouncedDataOnce();
             if (storage_ready && handleTransfer(buf, length)) refreshDeadline();
             if (storage_failed) return 2;
             break;

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -52,10 +52,8 @@ std::string baseName(const std::string& path) {
 std::map<size_t, int64_t> sent_part;
 std::ifstream input_file;
 
-// The ANNOUNCE datagram, kept verbatim after sendAnnounce() builds it so later
-// re-broadcasts are byte-identical: the receiver accepts a repeated same-session
-// ANNOUNCE only when it matches the latched one exactly (anything else is
-// treated as a hijack attempt and dropped).
+// ANNOUNCE datagram, kept verbatim: the receiver accepts a repeat only when it
+// is byte-identical to the latched one.
 std::vector<char> announce_packet;
 
 bool readFileAt(size_t offset, char* out, size_t len) {
@@ -190,8 +188,6 @@ bool sendAnnounce() {
     if (max_name > Protocol::MAX_NAME_LEN) max_name = Protocol::MAX_NAME_LEN;
     if (name.size() > max_name) name.resize(max_name);
 
-    // Built in its own buffer (not the shared `buffer`, which every sendPart
-    // overwrites) so the transfer can re-broadcast it unchanged later on.
     announce_packet.assign(Protocol::ANNOUNCE_FIXED + name.size(), 0);
     char* pkt = announce_packet.data();
     Protocol::writeHeader(pkt, Protocol::Type::Announce, session_id);
@@ -227,12 +223,8 @@ bool sendAnnounce() {
     return true;
 }
 
-// Best-effort re-broadcast of the stored ANNOUNCE. The initial burst leaves as
-// a sub-millisecond microburst, so a single loss window (cold NAT path, one
-// congested moment) used to strand every receiver: with no session latched it
-// silently discards all DATA and times out. Repeating the ANNOUNCE lets such a
-// receiver latch late and pull whatever it missed through the ordinary RESEND
-// path; a receiver already latched just refreshes its deadline.
+// Best-effort ANNOUNCE re-broadcast: lets a receiver that lost the initial
+// burst latch late and recover the missed parts via RESEND.
 void resendAnnounce() {
     if (announce_packet.empty()) return;
     if (sendto(_socket, announce_packet.data(), static_cast<int>(announce_packet.size()), 0,
@@ -281,10 +273,6 @@ bool serveResends(size_t total_parts, size_t& resent) {
         // empty packets can't drain the resend phase early.
         if (result < 0) {
             ttl--;
-            // Keep repeating the ANNOUNCE alongside FINISH for as long as the
-            // sender lingers: a receiver that lost every earlier copy (or was
-            // started late) can still latch here and pull the whole file
-            // through RESENDs.
             resendAnnounce();
             sendFinish();
             continue;
@@ -406,10 +394,8 @@ int run() {
     size_t delivered_parts = 0;
     int send_errno = 0;
 
-    // Repeat the ANNOUNCE a few times across the first second of DATA, so one
-    // lost initial burst no longer strands every receiver for the whole stream.
-    // A receiver that latches from a repeat recovers the parts it already
-    // missed via RESEND after FINISH.
+    // Repeat the ANNOUNCE across the first second of DATA, so one lost initial
+    // burst no longer strands every receiver.
     constexpr std::chrono::milliseconds announce_repeat_at[] = {200ms, 500ms, 1000ms};
     constexpr size_t announce_repeats = sizeof(announce_repeat_at) / sizeof(announce_repeat_at[0]);
     size_t announces_repeated = 0;
@@ -452,9 +438,7 @@ int run() {
               << ") in " << Progress::humanDuration(secs)
               << " at " << Progress::humanRate(rate) << std::endl;
 
-    // One more ANNOUNCE right before FINISH: a short transfer can drain inside
-    // the repeat window above, leaving a stranded receiver nothing to latch
-    // until the resend phase starts re-broadcasting below.
+    // A short transfer can drain before the repeats above fire.
     resendAnnounce();
     sendFinish();
 

--- a/src/Sender.cpp
+++ b/src/Sender.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <map>
 #include <random>
+#include <vector>
 #include <cerrno>
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
@@ -50,6 +51,12 @@ std::string baseName(const std::string& path) {
 // preallocates 67M entries (~3 GB) up front.
 std::map<size_t, int64_t> sent_part;
 std::ifstream input_file;
+
+// The ANNOUNCE datagram, kept verbatim after sendAnnounce() builds it so later
+// re-broadcasts are byte-identical: the receiver accepts a repeated same-session
+// ANNOUNCE only when it matches the latched one exactly (anything else is
+// treated as a hijack attempt and dropped).
+std::vector<char> announce_packet;
 
 bool readFileAt(size_t offset, char* out, size_t len) {
     input_file.clear();
@@ -183,18 +190,22 @@ bool sendAnnounce() {
     if (max_name > Protocol::MAX_NAME_LEN) max_name = Protocol::MAX_NAME_LEN;
     if (name.size() > max_name) name.resize(max_name);
 
-    Protocol::writeHeader(buffer, Protocol::Type::Announce, session_id);
-    Protocol::putU32(buffer + Protocol::HEADER_SIZE,     static_cast<uint32_t>(file_length));
-    Protocol::putU32(buffer + Protocol::HEADER_SIZE + 4, static_cast<uint32_t>(mtu));
-    memcpy(buffer + Protocol::HEADER_SIZE + 8, file_hash, 32);
-    Protocol::putU16(buffer + Protocol::HEADER_SIZE + 40, static_cast<uint16_t>(name.size()));
-    memcpy(buffer + Protocol::ANNOUNCE_FIXED, name.data(), name.size());
-    int announce_len = static_cast<int>(Protocol::ANNOUNCE_FIXED + name.size());
+    // Built in its own buffer (not the shared `buffer`, which every sendPart
+    // overwrites) so the transfer can re-broadcast it unchanged later on.
+    announce_packet.assign(Protocol::ANNOUNCE_FIXED + name.size(), 0);
+    char* pkt = announce_packet.data();
+    Protocol::writeHeader(pkt, Protocol::Type::Announce, session_id);
+    Protocol::putU32(pkt + Protocol::HEADER_SIZE,     static_cast<uint32_t>(file_length));
+    Protocol::putU32(pkt + Protocol::HEADER_SIZE + 4, static_cast<uint32_t>(mtu));
+    memcpy(pkt + Protocol::HEADER_SIZE + 8, file_hash, 32);
+    Protocol::putU16(pkt + Protocol::HEADER_SIZE + 40, static_cast<uint16_t>(name.size()));
+    memcpy(pkt + Protocol::ANNOUNCE_FIXED, name.data(), name.size());
+    int announce_len = static_cast<int>(announce_packet.size());
 
     int announce_sent = 0;
     int send_errno = 0;
     for (int i = 0; i < 3; ++i) {
-        if (sendto(_socket, buffer, announce_len, 0,
+        if (sendto(_socket, pkt, announce_len, 0,
                    reinterpret_cast<sockaddr*>(&broadcast_address),
                    sizeof(broadcast_address)) < 0) {
             send_errno = errno;
@@ -214,6 +225,21 @@ bool sendAnnounce() {
         std::cout << "Ok: Sent information about new file with size " << file_length << std::endl;
     }
     return true;
+}
+
+// Best-effort re-broadcast of the stored ANNOUNCE. The initial burst leaves as
+// a sub-millisecond microburst, so a single loss window (cold NAT path, one
+// congested moment) used to strand every receiver: with no session latched it
+// silently discards all DATA and times out. Repeating the ANNOUNCE lets such a
+// receiver latch late and pull whatever it missed through the ordinary RESEND
+// path; a receiver already latched just refreshes its deadline.
+void resendAnnounce() {
+    if (announce_packet.empty()) return;
+    if (sendto(_socket, announce_packet.data(), static_cast<int>(announce_packet.size()), 0,
+               reinterpret_cast<sockaddr*>(&broadcast_address),
+               sizeof(broadcast_address)) < 0) {
+        std::cerr << "Warning: Failed to re-send ANNOUNCE" << std::endl;
+    }
 }
 
 // Absolute ceiling on the whole resend-serving phase, expressed as a multiple of
@@ -255,6 +281,11 @@ bool serveResends(size_t total_parts, size_t& resent) {
         // empty packets can't drain the resend phase early.
         if (result < 0) {
             ttl--;
+            // Keep repeating the ANNOUNCE alongside FINISH for as long as the
+            // sender lingers: a receiver that lost every earlier copy (or was
+            // started late) can still latch here and pull the whole file
+            // through RESENDs.
+            resendAnnounce();
             sendFinish();
             continue;
         }
@@ -308,9 +339,10 @@ bool serveResends(size_t total_parts, size_t& resent) {
             // ignoring the sender's chosen rate on a shared LAN.
             pace();
         }
-        // Re-announce completion at most once a second.
+        // Re-announce the session and completion at most once a second.
         if (duration - lastFinishSendTime >= 1) {
             lastFinishSendTime = duration;
+            resendAnnounce();
             sendFinish();
         }
     }
@@ -373,7 +405,23 @@ int run() {
     size_t total_parts = Protocol::totalParts(file_length, static_cast<size_t>(mtu));
     size_t delivered_parts = 0;
     int send_errno = 0;
+
+    // Repeat the ANNOUNCE a few times across the first second of DATA, so one
+    // lost initial burst no longer strands every receiver for the whole stream.
+    // A receiver that latches from a repeat recovers the parts it already
+    // missed via RESEND after FINISH.
+    constexpr std::chrono::milliseconds announce_repeat_at[] = {200ms, 500ms, 1000ms};
+    constexpr size_t announce_repeats = sizeof(announce_repeat_at) / sizeof(announce_repeat_at[0]);
+    size_t announces_repeated = 0;
+    const auto stream_start = std::chrono::steady_clock::now();
+
     for (size_t part_index = 0; part_index < total_parts; ++part_index) {
+        if (announces_repeated < announce_repeats &&
+            std::chrono::steady_clock::now() - stream_start >=
+                announce_repeat_at[announces_repeated]) {
+            resendAnnounce();
+            ++announces_repeated;
+        }
         bool delivered = false;
         if (!sendPart(part_index, &delivered, &send_errno)) {
             reporter.finish();
@@ -404,6 +452,10 @@ int run() {
               << ") in " << Progress::humanDuration(secs)
               << " at " << Progress::humanRate(rate) << std::endl;
 
+    // One more ANNOUNCE right before FINISH: a short transfer can drain inside
+    // the repeat window above, leaving a stranded receiver nothing to latch
+    // until the resend phase starts re-broadcasting below.
+    resendAnnounce();
     sendFinish();
 
     size_t resent = 0;

--- a/tests/announce_drop_proxy.py
+++ b/tests/announce_drop_proxy.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+#
+# One-directional UDP proxy for the lost-ANNOUNCE test (tests/e2e_lostannounce.sh).
+# Listens on IN and forwards every datagram to OUT, except it drops the first
+# <count> ANNOUNCE (type=1) packets. This models the cold-path failure from
+# issue #42: the sender's initial ANNOUNCE burst is lost while every DATA packet
+# still arrives, so the receiver can only latch from a later re-broadcast and
+# must then recover the parts it missed through RESENDs.
+#
+#   announce_drop_proxy.py <in_port> <out_host> <out_port> <count>
+#
+# The receiver's RESENDs go straight to the sender (not through this proxy), so
+# recovery traffic is unaffected.
+
+import socket
+import sys
+
+MAGIC = b"FCST"
+TYPE_ANNOUNCE = 1
+HEADER_SIZE = 10  # magic(4) + version(1) + type(1) + session(4)
+
+
+def main(argv):
+    if len(argv) < 5:
+        print("usage: announce_drop_proxy.py <in_port> <out_host> <out_port> <count>",
+              file=sys.stderr)
+        return 2
+    in_port, out_host, out_port, count = int(argv[1]), argv[2], int(argv[3]), int(argv[4])
+
+    r = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    r.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    r.bind(("127.0.0.1", in_port))
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    dropped = 0
+    while True:
+        data, _ = r.recvfrom(65535)
+        if (dropped < count and len(data) >= HEADER_SIZE
+                and data[:4] == MAGIC and data[5] == TYPE_ANNOUNCE):
+            dropped += 1
+            print(f"dropped ANNOUNCE {dropped}/{count}", file=sys.stderr, flush=True)
+            continue
+        s.sendto(data, (out_host, out_port))
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main(sys.argv))
+    except KeyboardInterrupt:
+        pass  # the test kills us; exit quietly

--- a/tests/announce_drop_proxy.py
+++ b/tests/announce_drop_proxy.py
@@ -1,16 +1,10 @@
 #!/usr/bin/env python3
 #
-# One-directional UDP proxy for the lost-ANNOUNCE test (tests/e2e_lostannounce.sh).
-# Listens on IN and forwards every datagram to OUT, except it drops the first
-# <count> ANNOUNCE (type=1) packets. This models the cold-path failure from
-# issue #42: the sender's initial ANNOUNCE burst is lost while every DATA packet
-# still arrives, so the receiver can only latch from a later re-broadcast and
-# must then recover the parts it missed through RESENDs.
+# One-directional UDP proxy for tests/e2e_lostannounce.sh: forwards everything
+# except the first <count> ANNOUNCE (type=1) packets, modeling a lost initial
+# ANNOUNCE burst while every DATA packet still arrives.
 #
 #   announce_drop_proxy.py <in_port> <out_host> <out_port> <count>
-#
-# The receiver's RESENDs go straight to the sender (not through this proxy), so
-# recovery traffic is unaffected.
 
 import socket
 import sys

--- a/tests/e2e_lostannounce.sh
+++ b/tests/e2e_lostannounce.sh
@@ -1,20 +1,9 @@
 #!/usr/bin/env bash
 #
-# Lost-ANNOUNCE end-to-end test (issue #42). The sender's initial ANNOUNCE burst
-# leaves as a sub-millisecond microburst; if that one window is lost (cold NAT
-# path, momentary congestion), the receiver used to sit silently at "Waiting for
-# a sender..." discarding every DATA packet until ttl ran out — a whole failed
-# transfer with no diagnostic. The hardened sender repeats the ANNOUNCE during
-# the DATA stream, right before FINISH, and throughout the resend phase, and the
-# receiver reports un-announced DATA instead of staying silent.
-#
-# A one-directional proxy drops the first 4 ANNOUNCEs on the sender->receiver
-# path (the 3-packet burst plus the pre-FINISH repeat) while letting all DATA
-# through. The receiver must:
-#   * warn that data is arriving without an announcement (the new diagnostic),
-#   * latch from a later re-broadcast,
-#   * recover every missed part via RESEND,
-#   * and finish with a verified, bit-identical file.
+# Lost-ANNOUNCE end-to-end test: a proxy drops the sender's initial ANNOUNCE
+# burst (plus the pre-FINISH repeat) while letting all DATA through. The
+# receiver must warn about un-announced DATA, latch from a later re-broadcast,
+# recover every missed part via RESEND, and finish verified.
 #
 # Run via:
 #   ctest --test-dir build --output-on-failure
@@ -57,9 +46,8 @@ RECV_BIND=33901
 SEND_BIND=33902
 PROXY_IN=33903
 
-# The sender emits 3 burst ANNOUNCEs and (for a transfer that drains inside the
-# 200 ms repeat window) one more right before FINISH; drop all 4 so the receiver
-# can only latch from a resend-phase re-broadcast, with zero parts in hand.
+# 3 burst ANNOUNCEs + the pre-FINISH repeat: drop all 4 so the receiver can
+# only latch from a resend-phase re-broadcast.
 DROP_COUNT=4
 
 src="$WORKDIR/src.bin"
@@ -120,22 +108,17 @@ if ! grep -q "sha256 verified" "$recv_log"; then
     exit 1
 fi
 
-# Proof the scenario was actually exercised, not just missed by timing:
-# the proxy must have swallowed the whole initial burst...
+# Proof the scenario was exercised, not just missed by timing.
 if ! grep -q "dropped ANNOUNCE $DROP_COUNT/$DROP_COUNT" "$proxy_log"; then
     echo "FAIL: proxy did not drop $DROP_COUNT ANNOUNCEs (scenario not exercised)"
     tail -20 "$proxy_log"
     exit 1
 fi
-# ...the receiver must have seen un-announced DATA and said so (the new
-# diagnostic instead of a silent 'Waiting for a sender')...
 if ! grep -q "receiving data without an announcement" "$recv_log"; then
     echo "FAIL: receiver never warned about DATA arriving without an ANNOUNCE"
     tail -20 "$recv_log"
     exit 1
 fi
-# ...and it can only have completed by latching late and pulling the missed
-# parts through RESENDs.
 resend_count=$(grep -c "Request part of file with index" "$recv_log" || true)
 if [ "$resend_count" -eq 0 ]; then
     echo "FAIL: file matched but the RESEND recovery path was never exercised"

--- a/tests/e2e_lostannounce.sh
+++ b/tests/e2e_lostannounce.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Lost-ANNOUNCE end-to-end test (issue #42). The sender's initial ANNOUNCE burst
+# leaves as a sub-millisecond microburst; if that one window is lost (cold NAT
+# path, momentary congestion), the receiver used to sit silently at "Waiting for
+# a sender..." discarding every DATA packet until ttl ran out — a whole failed
+# transfer with no diagnostic. The hardened sender repeats the ANNOUNCE during
+# the DATA stream, right before FINISH, and throughout the resend phase, and the
+# receiver reports un-announced DATA instead of staying silent.
+#
+# A one-directional proxy drops the first 4 ANNOUNCEs on the sender->receiver
+# path (the 3-packet burst plus the pre-FINISH repeat) while letting all DATA
+# through. The receiver must:
+#   * warn that data is arriving without an announcement (the new diagnostic),
+#   * latch from a later re-broadcast,
+#   * recover every missed part via RESEND,
+#   * and finish with a verified, bit-identical file.
+#
+# Run via:
+#   ctest --test-dir build --output-on-failure
+#
+# Or directly:
+#   BINARY=build/filecast bash tests/e2e_lostannounce.sh
+#
+set -euo pipefail
+
+BINARY="${BINARY:-./filecast}"
+PYTHON="${PYTHON:-python3}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ ! -x "$BINARY" ]; then
+    echo "Error: $BINARY not found or not executable. Build first." >&2
+    exit 1
+fi
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+    echo "Error: $PYTHON not found in PATH; the announce-drop proxy needs Python 3." >&2
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d -t fb-e2e-lostannounce.XXXXXX)"
+PROXY_PID=""
+RECV_PID=""
+
+cleanup() {
+    [ -n "$RECV_PID"  ] && kill "$RECV_PID"  2>/dev/null || true
+    [ -n "$PROXY_PID" ] && kill "$PROXY_PID" 2>/dev/null || true
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# Own 339xx port block so ctest -j doesn't collide with the other e2e tests.
+# Topology (all on 127.0.0.1):
+#   sender bind = 33902, sender target -> 33903 (proxy in)
+#   proxy: 33903 -> 33901 (drops the first ANNOUNCEs, forwards the rest)
+#   receiver bind = 33901, receiver target -> 33902 (RESENDs go straight back)
+RECV_BIND=33901
+SEND_BIND=33902
+PROXY_IN=33903
+
+# The sender emits 3 burst ANNOUNCEs and (for a transfer that drains inside the
+# 200 ms repeat window) one more right before FINISH; drop all 4 so the receiver
+# can only latch from a resend-phase re-broadcast, with zero parts in hand.
+DROP_COUNT=4
+
+src="$WORKDIR/src.bin"
+dst="$WORKDIR/out.bin"
+recv_log="$WORKDIR/recv.log"
+send_log="$WORKDIR/send.log"
+proxy_log="$WORKDIR/proxy.log"
+
+echo "==> generating 200 KiB file"
+dd if=/dev/urandom of="$src" bs=1024 count=200 status=none
+
+echo "==> starting announce-drop proxy ($PROXY_IN -> $RECV_BIND, dropping first $DROP_COUNT ANNOUNCEs)"
+"$PYTHON" "$SCRIPT_DIR/announce_drop_proxy.py" \
+    "$PROXY_IN" 127.0.0.1 "$RECV_BIND" "$DROP_COUNT" \
+    > "$proxy_log" 2>&1 &
+PROXY_PID=$!
+sleep 0.5  # let the proxy bind
+
+echo "==> starting receiver (bind=$RECV_BIND, target=$SEND_BIND)"
+"$BINARY" receive "$dst" --to 127.0.0.1 --verbose \
+          --bind-port "$RECV_BIND" --port "$SEND_BIND" \
+          --ttl 15 --delay-ms 0 \
+    > "$recv_log" 2>&1 &
+RECV_PID=$!
+sleep 1
+
+echo "==> starting sender (bind=$SEND_BIND, target=$PROXY_IN)"
+if ! "$BINARY" send "$src" --to 127.0.0.1 \
+               --bind-port "$SEND_BIND" --port "$PROXY_IN" \
+               --ttl 10 --delay-ms 0 \
+        > "$send_log" 2>&1; then
+    echo "FAIL: sender exited non-zero"
+    echo "--- sender log (tail):"; tail -30 "$send_log"
+    echo "--- proxy log (tail):";  tail -30 "$proxy_log"
+    exit 1
+fi
+
+if ! wait "$RECV_PID"; then
+    echo "FAIL: receiver exited non-zero (stranded by the lost ANNOUNCE burst?)"
+    echo "--- receiver log (tail):"; tail -30 "$recv_log"
+    echo "--- proxy log (tail):";    tail -30 "$proxy_log"
+    exit 1
+fi
+RECV_PID=""
+
+kill "$PROXY_PID" 2>/dev/null || true
+wait "$PROXY_PID" 2>/dev/null || true
+PROXY_PID=""
+
+if [ ! -f "$dst" ] || ! cmp -s "$src" "$dst"; then
+    echo "FAIL: received file missing or does not match source"
+    echo "--- receiver log (tail):"; tail -30 "$recv_log"
+    exit 1
+fi
+if ! grep -q "sha256 verified" "$recv_log"; then
+    echo "FAIL: receiver did not verify the transfer"
+    tail -20 "$recv_log"
+    exit 1
+fi
+
+# Proof the scenario was actually exercised, not just missed by timing:
+# the proxy must have swallowed the whole initial burst...
+if ! grep -q "dropped ANNOUNCE $DROP_COUNT/$DROP_COUNT" "$proxy_log"; then
+    echo "FAIL: proxy did not drop $DROP_COUNT ANNOUNCEs (scenario not exercised)"
+    tail -20 "$proxy_log"
+    exit 1
+fi
+# ...the receiver must have seen un-announced DATA and said so (the new
+# diagnostic instead of a silent 'Waiting for a sender')...
+if ! grep -q "receiving data without an announcement" "$recv_log"; then
+    echo "FAIL: receiver never warned about DATA arriving without an ANNOUNCE"
+    tail -20 "$recv_log"
+    exit 1
+fi
+# ...and it can only have completed by latching late and pulling the missed
+# parts through RESENDs.
+resend_count=$(grep -c "Request part of file with index" "$recv_log" || true)
+if [ "$resend_count" -eq 0 ]; then
+    echo "FAIL: file matched but the RESEND recovery path was never exercised"
+    tail -20 "$recv_log"
+    exit 1
+fi
+
+echo "PASS: lost ANNOUNCE burst survived — receiver warned, latched late, recovered $resend_count part request(s), sha256 verified"
+echo
+echo "Lost-ANNOUNCE E2E test passed."


### PR DESCRIPTION
Closes #42

## Problem

The ANNOUNCE was the only packet class with no retransmission path: all three copies left as a sub-millisecond microburst at `t≈0` and were never repeated. One unlucky loss window (a cold NAT/conntrack path, a momentary congestion spike, a Wi-Fi broadcast drop) stranded every receiver — DATA was silently discarded until `--ttl` ran out, with nothing but `Waiting for a sender` to explain a whole failed transfer. Observed on a v1.0.1 WAN smoke test where `tcpdump` showed all ~2800 DATA packets arriving while the receiver timed out with 0 parts.

## Changes

Scope is **A + B + C** from the issue (A implemented as in-stream repeats, so transfer start is not delayed), no wire-format change — still protocol v3:

- **Sender** keeps the ANNOUNCE datagram (`announce_packet`) and re-broadcasts it byte-identically via `resendAnnounce()`:
  - a few times across the first second of DATA (200 ms / 500 ms / 1 s), so a receiver that lost the burst latches mid-stream and recovers the missed parts through ordinary RESENDs;
  - once right before FINISH — a short transfer can drain inside the repeat window;
  - roughly once a second throughout the resend phase, alongside the periodic FINISH re-broadcast, which also lets a late-started receiver join and pull the whole file while the sender lingers.
- **Receiver** warns once when DATA arrives without a latched session, so a lost ANNOUNCE is no longer indistinguishable from "no sender at all".

Byte-identical repeats are what make this compatible with the same-session ANNOUNCE hijack guard from #31/#40: a latched receiver accepts the repeat only as a deadline refresh; anything differing is still dropped as a conflict (pinned by `e2e_hijack`, still green).

## Testing

- New `tests/e2e_lostannounce.sh` + `tests/announce_drop_proxy.py`: the proxy swallows the sender's whole initial ANNOUNCE burst (and the pre-FINISH repeat) while letting every DATA packet through — reproducing the issue scenario. The test requires the new diagnostic to fire, a late latch from a re-broadcast, full RESEND recovery, and a bit-identical `sha256 verified` file.
- Full local suite: 11/11 passing (`unit`, `e2e`, `e2e_diskfull`, `e2e_syncfail`, `e2e_sendfail`, `e2e_lossy`, `e2e_corrupt`, `e2e_hijack`, `e2e_flood`, `e2e_prelatch`, `e2e_lostannounce`).

`docs/PROTOCOL.md` step 1 now documents the repeat schedule.